### PR TITLE
[web] converting all release notes into components

### DIFF
--- a/src/app/news/release-page/release-pages.ts
+++ b/src/app/news/release-page/release-pages.ts
@@ -49,15 +49,15 @@ function createChangeLogComponent(releaseNumber, releaseInfo) {
     @ViewChildren(BugFix) bugFixes: QueryList<BugFix>;
     @ViewChildren(NewComponent) newComponents: QueryList<NewComponent>;
 
-    nbBreakingChanges = 0;
-    nbBugFixes = 0;
-    nbNewComponents = 0;
+    nbBreakingChanges: number;
+    nbBugFixes: number;
+    nbNewComponents: number;
 
     ngAfterViewInit(): void {
       // No need to subscribe to changes, we know this is all just static
-      this.nbBreakingChanges = this.breakingChanges.length;
-      this.nbBugFixes = this.bugFixes.length;
-      this.nbNewComponents = this.newComponents.length;
+      this.nbBreakingChanges = this.breakingChanges ? this.breakingChanges.length : 0;
+      this.nbBugFixes = this.bugFixes ? this.bugFixes.length : 0;
+      this.nbNewComponents = this.newComponents ? this.newComponents.length : 0;
     }
 
     releaseNumber = releaseNumber;

--- a/src/pages/documentation/alerts.html
+++ b/src/pages/documentation/alerts.html
@@ -1,235 +1,234 @@
+<article>
+    <h5 class="component-summary" id="an-alert-is-a-banner-that-uses-text-color-and-an-icon-to-denote-the-severity-of-a-message">An alert is a banner that uses text, color, and an icon to denote the severity of a message.</h5>
 
-<article><h5 class="component-summary" id="an-alert-is-a-banner-that-uses-text-color-and-an-icon-to-denote-the-severity-of-a-message">An alert is a banner that uses text, color, and an icon to denote the severity of a message.</h5>
+    <h6 id="alert">.alert</h6>
 
-  <h6 id="alert">.alert</h6>
+    <p>This class is a wrapper around <code class="clr-code">.alert-item</code> and the
+        <code class="clr-code">.close</code> button. Place the <code class="clr-code">.close</code> button before the alert items.</p>
 
-  <p>This class is a wrapper around <code class="clr-code">.alert-item</code> and the
-    <code class="clr-code">.close</code> button. Place the <code class="clr-code">.close</code>
-    button before the alert items.</p>
+    <h6 id="alert-item">.alert-item</h6>
 
-  <h6 id="alert-item">.alert-item</h6>
+    <p>This class is a wrapper around <code class="clr-code">.alert-text</code> and <code class="clr-code">.alert-actions</code>.</p>
 
-  <p>This class is a wrapper around <code class="clr-code">.alert-text</code> and <code class="clr-code">.alert-actions</code>.</p>
+    <h6 id="alert-actions">.alert-actions</h6>
 
-  <h6 id="alert-actions">.alert-actions</h6>
+    <p><code class="clr-code">.alert-actions</code> can consist of dropdowns or links. Each action should extend the <code class="clr-code">.alert-action</code> class.</p>
 
-  <p><code class="clr-code">.alert-actions</code> can consist of dropdowns or links.
-    Each action should extend the <code class="clr-code">.alert-action</code> class.</p>
+    <h3 id="types">Types</h3>
 
-  <h3 id="types">Types</h3>
+    <p>Clarity has error, warning, information, and success alerts denoted by the following classes:</p>
 
-  <p>Clarity has error, warning, information, and success alerts denoted by the following classes:</p>
+    <ul class="list">
+        <li>.alert-danger</li>
+        <li>.alert-warning</li>
+        <li>.alert-info</li>
+        <li>.alert-success</li>
+    </ul>
 
-  <ul class="list">
-    <li>.alert-danger</li>
-    <li>.alert-warning</li>
-    <li>.alert-info</li>
-    <li>.alert-success</li>
-  </ul>
+    <clr-alert-demo-styles></clr-alert-demo-styles>
 
-  <clr-alert-demo-styles></clr-alert-demo-styles>
+    <h3 id="placement">Placement</h3>
 
-  <h3 id="placement">Placement</h3>
+    <h5 id="alerts-in-the-content-area">Alerts in the Content Area</h5>
+    <clr-alert-demo-content-area></clr-alert-demo-content-area>
 
-  <h5 id="alerts-in-the-content-area">Alerts in the Content Area</h5>
-  <clr-alert-demo-content-area></clr-alert-demo-content-area>
+    <h5 id="alerts-in-cards">Alerts in Cards</h5>
+    <clr-alert-demo-cards></clr-alert-demo-cards>
 
-  <h5 id="alerts-in-cards">Alerts in Cards</h5>
-  <clr-alert-demo-cards></clr-alert-demo-cards>
+    <h5 id="alerts-in-modals">Alerts in Modals</h5>
+    <clr-alert-demo-modals></clr-alert-demo-modals>
 
-  <h5 id="alerts-in-modals">Alerts in Modals</h5>
-  <clr-alert-demo-modals></clr-alert-demo-modals>
+    <h3 id="size">Size</h3>
 
-  <h3 id="size">Size</h3>
+    <p>Use the <code class="clr-code">.alert-sm</code> class with <code class="clr-code">.alert</code> for an alert 24 pixels in height. The default is 36 pixels.</p>
 
-  <p>Use the <code class="clr-code">.alert-sm</code> class with <code class="clr-code">.alert</code> for an alert 24 pixels in height. The default is 36 pixels.</p>
+    <clr-alert-demo-sizes></clr-alert-demo-sizes>
 
-  <clr-alert-demo-sizes></clr-alert-demo-sizes>
+    <h3 id="app-level-alerts">App-Level Alerts</h3>
 
-  <h3 id="app-level-alerts">App-Level Alerts</h3>
+    <h6 id="alert-app-level">.alert-app-level</h6>
 
-  <h6 id="alert-app-level">.alert-app-level</h6>
+    <p>This class must be applied with <code class="clr-code">.alert</code> to render an app-level alert.</p>
 
-  <p>This class must be applied with <code class="clr-code">.alert</code> to render an app-level alert.</p>
+    <clr-alert-demo-app-level></clr-alert-demo-app-level>
 
-  <clr-alert-demo-app-level></clr-alert-demo-app-level>
+    <h2 id="angular-component">Angular Component</h2>
 
-  <h2 id="angular-component">Angular Component</h2>
+    <h3 id="summary-of-options">Summary of Options</h3>
 
-  <h3 id="summary-of-options">Summary of Options</h3>
+    <table class="table">
+        <thead>
+            <tr>
+                <th class="left">Input</th>
+                <th class="left hidden-xs-down">Values</th>
+                <th class="hidden-xs-down">Default</th>
+                <th class="left">Effect</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td class="left">
+                    <b>[clrAlertClosable]</b>
+                    <div class="hidden-sm-up">Type: Boolean</div>
+                    <div class="hidden-sm-up">Default: true</div>
+                </td>
+                <td class="left hidden-xs-down">true, false</td>
+                <td class="hidden-xs-down">true</td>
+                <td class="left">If false, the alert will not be closable by clicking on the top-right "x".</td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <b>[(clrAlertClosed)]</b>
+                    <div class="hidden-sm-up">Type: Boolean</div>
+                    <div class="hidden-sm-up">Default: false</div>
+                </td>
+                <td class="left hidden-xs-down">true, false</td>
+                <td class="hidden-xs-down">false</td>
+                <td class="left">
+                    Two-way binding on the state of the alert: opened or closed.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <b>[clrAlertType]</b>
+                    <div class="hidden-sm-up">Type: String</div>
+                    <div class="hidden-sm-up">Default:<br />"alert-info"</div>
+                </td>
+                <td class="left hidden-xs-down">"alert-info", "alert-warning", "alert-success" and "alert-danger"</td>
+                <td class="hidden-xs-down">"alert-info"</td>
+                <td class="left">Sets the type of the alert.</td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <b>[clrAlertSizeSmall]</b>
+                    <div class="hidden-sm-up">Type: Boolean</div>
+                    <div class="hidden-sm-up">Default: false</div>
+                </td>
+                <td class="left hidden-xs-down">true, false</td>
+                <td class="hidden-xs-down">false</td>
+                <td class="left">If true, renders a small alert.</td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <b>[clrAlertAppLevel]</b>
+                    <div class="hidden-sm-up">Type: Boolean</div>
+                    <div class="hidden-sm-up">Default: false</div>
+                </td>
+                <td class="left hidden-xs-down">true, false</td>
+                <td class="hidden-xs-down">false</td>
+                <td class="left">If true, renders an app-level alert.</td>
+            </tr>
+        </tbody>
+    </table>
 
-  <table class="table">
-    <thead>
-    <tr>
-      <th class="left">Input</th>
-      <th class="left hidden-xs-down">Values</th>
-      <th class="hidden-xs-down">Default</th>
-      <th class="left">Effect</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr>
-      <td class="left">
-        <b>[clrAlertClosable]</b>
-        <div class="hidden-sm-up">Type: Boolean</div>
-        <div class="hidden-sm-up">Default: true</div>
-      </td>
-      <td class="left hidden-xs-down">true, false</td>
-      <td class="hidden-xs-down">true</td>
-      <td class="left">If false, the alert will not be closable by clicking on the top-right "x".</td>
-    </tr>
-    <tr>
-      <td class="left">
-        <b>[(clrAlertClosed)]</b>
-        <div class="hidden-sm-up">Type: Boolean</div>
-        <div class="hidden-sm-up">Default: false</div>
-      </td>
-      <td class="left hidden-xs-down">true, false</td>
-      <td class="hidden-xs-down">false</td>
-      <td class="left">
-        Two-way binding on the state of the alert: opened or closed.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <b>[clrAlertType]</b>
-        <div class="hidden-sm-up">Type: String</div>
-        <div class="hidden-sm-up">Default:<br />"alert-info"</div>
-      </td>
-      <td class="left hidden-xs-down">"alert-info", "alert-warning", "alert-success" and "alert-danger"</td>
-      <td class="hidden-xs-down">"alert-info"</td>
-      <td class="left">Sets the type of the alert.</td>
-    </tr>
-    <tr>
-      <td class="left">
-        <b>[clrAlertSizeSmall]</b>
-        <div class="hidden-sm-up">Type: Boolean</div>
-        <div class="hidden-sm-up">Default: false</div>
-      </td>
-      <td class="left hidden-xs-down">true, false</td>
-      <td class="hidden-xs-down">false</td>
-      <td class="left">If true, renders a small alert.</td>
-    </tr>
-    <tr>
-      <td class="left">
-        <b>[clrAlertAppLevel]</b>
-        <div class="hidden-sm-up">Type: Boolean</div>
-        <div class="hidden-sm-up">Default: false</div>
-      </td>
-      <td class="left hidden-xs-down">true, false</td>
-      <td class="hidden-xs-down">false</td>
-      <td class="left">If true, renders an app-level alert.</td>
-    </tr>
-    </tbody>
-  </table>
+    <h5 id="examples">Examples</h5>
 
-  <h5 id="examples">Examples</h5>
+    <h6 id="clralertclosable-set-to-false-default-value-is-true">1. clrAlertClosable set to false. Default value is true.</h6>
 
-  <h6 id="clralertclosable-set-to-false-default-value-is-true">1. clrAlertClosable set to false. Default value is true.</h6>
+    <clr-alert-not-closable-demo-angular></clr-alert-not-closable-demo-angular>
 
-  <clr-alert-not-closable-demo-angular></clr-alert-not-closable-demo-angular>
+    <h6 id="clralerttype-set-to-alert-success-default-value-is-alert-info-accepts-values-same-as-the-static-alert-type-classes">2. clrAlertType set to alert-success. Default value is alert-info. Accepts values same as the static alert type classes.</h6>
 
-  <h6 id="clralerttype-set-to-alert-success-default-value-is-alert-info-accepts-values-same-as-the-static-alert-type-classes">2. clrAlertType set to alert-success. Default value is alert-info. Accepts values same as the static alert type classes.</h6>
+    <clr-alert-success-demo-angular></clr-alert-success-demo-angular>
 
-  <clr-alert-success-demo-angular></clr-alert-success-demo-angular>
+    <h6 id="clralertsizesmall-set-to-true-default-value-is-false">3. clrAlertSizeSmall set to true. Default value is false.</h6>
 
-  <h6 id="clralertsizesmall-set-to-true-default-value-is-false">3. clrAlertSizeSmall set to true. Default value is false.</h6>
+    <clr-alert-small-demo-angular></clr-alert-small-demo-angular>
 
-  <clr-alert-small-demo-angular></clr-alert-small-demo-angular>
+    <h6 id="binding-to-the-clralertclosedchange-event">4. Binding to the clrAlertClosedChange event.</h6>
 
-  <h6 id="binding-to-the-clralertclosedchange-event">4. Binding to the clrAlertClosedChange event.</h6>
+    <clr-alert-close-event-demo-angular></clr-alert-close-event-demo-angular>
 
-  <clr-alert-close-event-demo-angular></clr-alert-close-event-demo-angular>
+    <h6 id="clralertapplevel-set-to-true-default-is-false">5. clrAlertAppLevel set to true. Default is false.</h6>
 
-  <h6 id="clralertapplevel-set-to-true-default-is-false">5. clrAlertAppLevel set to true. Default is false.</h6>
+    <clr-alert-app-level-demo-angular></clr-alert-app-level-demo-angular>
 
-  <clr-alert-app-level-demo-angular></clr-alert-app-level-demo-angular>
+    <h2 id="guidelines">Using Standard Alerts</h2>
 
-  <h2 id="guidelines">Using Standard Alerts</h2>
+    <p>Standard alerts are part of the content area. These alerts are for notifying users that a particular component or area of the screen needs attention. Standard alerts have four levels, denoted by color and icon. From most to least severe, they are:</p>
 
-  <p>Standard alerts are part of the content area.  These alerts are for notifying users that a particular component or area of the screen needs attention.  Standard alerts have four levels, denoted by color and icon. From most to least severe, they are:</p>
+    <ul class="list">
+        <li>Error–a problem needs fixing</li>
+        <li>Warning–an action might have a harmful outcome</li>
+        <li>Info–a situation needs attention, at some point</li>
+        <li>Success–a significant achievement occurred</li>
+    </ul>
 
-  <ul class="list">
-    <li>Error–a problem needs fixing</li>
-    <li>Warning–an action might have a harmful outcome</li>
-    <li>Info–a situation needs attention, at some point</li>
-    <li>Success–a significant achievement occurred</li>
-  </ul>
+    <p>Other choices for displaying messages are <a routerLink="/documentation/input-fields">input field validations</a> and <a routerLink="/documentation/modals">modals</a> . However, these components require users to take action before proceeding.</p>
 
-  <p>Other choices for displaying messages are <a href="/clarity/documentation/input-fields">input field validations</a>  and <a href="/clarity/documentation/modals">modals</a> .  However, these components require users to take action before proceeding.</p>
+    <h3 id="placement-and-size">Placement and Size</h3>
 
-  <h3 id="placement-and-size">Placement and Size</h3>
+    <p>Alert positioning should be contextual to the component or area to which it applies. For example, if the alert applies to the entire content area, place it at the top and span the width of that area.</p>
 
-  <p>Alert positioning should be contextual to the component or area to which it applies. For example, if the alert applies to the entire content area, place it at the top and span the width of that area.</p>
+    <p>Base the height of the alert (36 or 24 pixels) on its location. The larger alert is for use in the application’s main content area, modals, and wizards. The smaller alert is for use in cards.</p>
 
-  <p>Base the height of the alert (36 or 24 pixels) on its location.  The larger alert is for use in the application’s main content area, modals, and wizards.  The smaller alert is for use in cards.</p>
+    <h3 id="closing-alerts">Closing Alerts</h3>
 
-  <h3 id="closing-alerts">Closing Alerts</h3>
+    <p>A close button (X) serves as a method for users to acknowledge the alert. It also allows users to declutter the view. Omit the close button if the alert should be persistent.</p>
 
-  <p>A close button (X) serves as a method for users to acknowledge the alert.  It also allows users to declutter the view. Omit the close button if the alert should be persistent.</p>
+    <h3 id="message-text">Message Text</h3>
 
-  <h3 id="message-text">Message Text</h3>
+    <p>Keep the message text short and concise. If combining multiple messages in a single alert, make sure that the messages are of the same type. Avoid mixing error and warning messages.</p>
 
-  <p>Keep the message text short and concise.  If combining multiple messages in a single alert, make sure that the messages are of the same type.  Avoid mixing error and warning messages.</p>
+    <h3 id="stacking-alerts">Stacking Alerts</h3>
 
-  <h3 id="stacking-alerts">Stacking Alerts</h3>
+    <p>When showing multiple alerts, stack from most severe to least severe:</p>
 
-  <p>When showing multiple alerts, stack from most severe to least severe:</p>
+    <ol class="list">
+        <li>Error</li>
+        <li>Warning</li>
+        <li>Info</li>
+        <li>Success</li>
+    </ol>
 
-  <ol class="list">
-    <li>Error</li>
-    <li>Warning</li>
-    <li>Info</li>
-    <li>Success</li>
-  </ol>
+    <p>Stack up to three alerts. For more than three, consider an alternate pattern, such as displaying the information on another page.</p>
 
-  <p>Stack up to three alerts. For more than three, consider an alternate pattern, such as displaying the information on another page.</p>
+    <h3 id="actions">Actions</h3>
 
-  <h3 id="actions">Actions</h3>
+    <p>You can display up to two actions in an alert. For more than two actions, use a dropdown menu, limiting the number of items to five.</p>
 
-  <p>You can display up to two actions in an alert.  For more than two actions, use a dropdown menu, limiting the number of items to five.</p>
+    <p>The most common course of action goes at the top of the menu, destructive actions at the bottom. Avoid placing destructive actions directly in the alert.</p>
 
-  <p>The most common course of action goes at the top of the menu, destructive actions at the bottom.  Avoid placing destructive actions directly in the alert.</p>
+    <p>Actions in standard alerts are represented by links because links take up less space than buttons and are light in appearance.
+        <!-- One line is 36 pixels tall using links.  With flat buttons, the line is taller to accommodate the button state change. -->
+    </p>
 
-  <p>Actions in standard alerts are represented by links because  links take up less space than buttons and are light in appearance.  <!-- One line is 36 pixels tall using links.  With flat buttons, the line is taller to accommodate the button state change. --></p>
+    <h3 id="color">Color</h3>
 
-  <h3 id="color">Color</h3>
+    <p>Alerts have their own color palette of red, yellow, green, and blue. They are not styled with Stoplight colors to avoid competition with call-to-action buttons.</p>
 
-  <p>Alerts have their own color palette of red, yellow, green, and blue. They are not styled with Stoplight colors to avoid competition with call-to-action buttons.</p>
+    <h2 id="using-app-level-alerts">Using App-Level Alerts</h2>
 
-  <h2 id="using-app-level-alerts">Using App-Level Alerts</h2>
+    <p>An app-level alert appears at the top of the screen, above the application header. This alert is reserved for a single, system-level message.</p>
 
-  <p>An app-level alert appears at the top of the screen, above the application header.  This alert is reserved for a single, system-level message.</p>
+    <p>App-level alerts have three severity levels:</p>
 
-  <p>App-level alerts have three severity levels:</p>
+    <table class="table .table-noborder ">
+        <tr>
+            <th class="left">Type</th>
+            <th class="left">Example</th>
+        </tr>
+        <tr>
+            <td class="left">Error</td>
+            <td class="left">A problem exists with a server</td>
+        </tr>
+        <tr>
+            <td class="left">Warning</td>
+            <td class="left">A license is about to expire</td>
+        </tr>
+        <tr>
+            <td valign="top" class="left">Info</td>
+            <td class="left"> A trial is about to end<br /> Support is required for a feature </td>
+        </tr>
+    </table>
 
-  <table class="table .table-noborder ">
-    <tr>
-      <th class="left">Type</th>
-      <th class="left">Example</th>
-    </tr>
-    <tr>
-      <td class="left">Error</td>
-      <td class="left">A problem exists with a server</td>
-    </tr>
-    <tr>
-      <td class="left">Warning</td>
-      <td class="left">A license is about to expire</td>
-    </tr>
-    <tr>
-      <td valign="top" class="left">Info</td>
-      <td class="left"> A trial is about to end<br />
-        Support is required for a feature </td>
-    </tr>
-  </table>
+    <h3 id="guidelines">Guidelines</h3>
 
-  <h3 id="guidelines">Guidelines</h3>
-
-  <ul class="list">
-    <li>Show only one app-level alert at a time.</li>
-    <li>Keep the message text to one line–don’t wrap the text.</li>
-    <li>Include up to two actions and keep button labels concise.</li>
-    <li>Do not include a menu within the alert.</li>
-    <li>When appropriate, include a close icon so that the app-level alert can be dismissed.</li>
-  </ul>
+    <ul class="list">
+        <li>Show only one app-level alert at a time.</li>
+        <li>Keep the message text to one line–don’t wrap the text.</li>
+        <li>Include up to two actions and keep button labels concise.</li>
+        <li>Do not include a menu within the alert.</li>
+        <li>When appropriate, include a close icon so that the app-level alert can be dismissed.</li>
+    </ul>
 </article>

--- a/src/pages/documentation/app-layout.html
+++ b/src/pages/documentation/app-layout.html
@@ -1,187 +1,188 @@
+<article>
+    <h5 class="component-summary" id="a-properly-structured-layout-enforces-an-optimal-consistent-experience-across-applications">A properly structured layout enforces an optimal, consistent experience across applications.</h5>
 
-<article><h5 class="component-summary" id="a-properly-structured-layout-enforces-an-optimal-consistent-experience-across-applications">A properly structured layout enforces an optimal, consistent experience across applications.</h5>
+    <h3 id="layout">Layout</h3>
 
-  <h3 id="layout">Layout</h3>
+    <p><strong>.main-container:</strong></p>
+    <div>
+        The <code class="clr-code">.main-container</code> is a vertical flexbox which wraps the following components:
+        <ul class="list">
+            <li><a routerLink="/documentation/alerts">App-Level Alert</a></li>
+            <li><a routerLink="/documentation/header">Header</a></li>
+            <li><a routerLink="/documentation/header">Subnav</a></li>
+            <li>Content Container</li>
+        </ul>
+    </div>
 
-  <p><strong>.main-container:</strong></p>
-  <div>
-    The <code class="clr-code">.main-container</code> is a vertical flexbox which wraps the following components:
+    <p><strong>Note:</strong> Although Clarity does not have a footer component, a custom footer can be added in the main-container.</p>
+
+    <p><strong>.content-container:</strong></p>
+    <div>
+        The <code class="clr-code">.content-container</code> is a horizontal flexbox which wraps the following components:
+        <ul class="list">
+            <li>Content Area</li>
+            <li><a routerLink="/documentation/sidenav">Sidenav</a></li>
+        </ul>
+    </div>
+
+    <clr-layout-all-demo></clr-layout-all-demo>
+
+    <h3 id="guidelines">Basic Structure</h3>
+
+    <p>Two constants of an app built in Clarity are the header and content area. These are the blocks upon which you build your app model.</p>
+
+    <div class="row cozy-sm">
+        <div class="col-xs-12 col-md-5">
+            <img src="/assets/images/documentation/app-layout/header_contentarea.png?1481674789140619000" alt="Header and Content Area" />
+        </div>
+        <div class="col-xs-12 col-md-7">
+            <h5 style="margin-top:0">Header</h5>
+            The <a routerLink="/documentation/header">header</a> is for branding and app-level elements such as navigation, search, and account settings.
+
+            <h5>Content Area</h5>
+            The content area is where users focus their attention most of the time, gathering information and performing tasks–it is the canvas for your application. As the largest portion of your app, the content area is always visible.
+        </div>
+    </div>
+
+    <h3 id="layout-1">Layout</h3>
+    <p>Your layout should reflect the information or workflow of the selected <a routerLink="/documentation/navigation">navigation</a>. When laying out the content, keep the following in mind:</p>
+
     <ul class="list">
-      <li><a href="/clarity/documentation/alerts">App-Level Alert</a></li>
-      <li><a href="/clarity/documentation/header">Header</a></li>
-      <li><a href="/clarity/documentation/header">Subnav</a></li>
-      <li>Content Container</li>
+        <li>The flow of content–how to create a hierarchy and layout that draws attention to the areas of importance</li>
+        <li>The importance of designing to the <a routerLink="/documentation/grid">grid</a></li>
+        <li>How to aid users in completing their tasks</li>
+        <li>How to handle large amounts of data</li>
+        <li>Responsive design (if that is part of your product’s goals)</li>
     </ul>
-  </div>
 
-  <p><strong>Note:</strong> Although Clarity does not have a footer component, a custom footer can be added in the main-container.</p>
+    <h5 id="common-layout-patterns">Common Layout Patterns</h5>
 
-  <p><strong>.content-container:</strong></p>
-  <div>
-    The <code class="clr-code">.content-container</code> is a horizontal flexbox which wraps the following components:
+    <p>Content can consist of any of the <a routerLink="/documentation/">Clarity components</a>, or no components and just information. Following are common layout patterns and recommended usage. For information on navigation components, header, subnav,
+        and sidenav, see <a routerLink="/documentation/navigation">Navigation</a>.</p>
+
+    <h6 id="cards">Cards</h6>
+
+    <div class="row cozy-sm">
+        <div class="col-xs-12 col-md-5">
+            <img src="/assets/images/documentation/app-layout/cards.png?1481674789140619000" alt="Cards" />
+        </div>
+        <div class="col-xs-12 col-md-7">
+            <div>
+                <a routerLink="/documentation/cards">Cards</a> are for presenting high-level information and guiding users to related actions and details. Cards might include a combination of text, images, and data visualizations.
+            </div>
+            <p>
+                Benefits of using cards include:
+            </p>
+            <ul class="list">
+                <li>Ability to see data in a collection</li>
+                <li>Facilitates scanning of information</li>
+                <li>Works well across platforms</li>
+            </ul>
+        </div>
+    </div>
+
+    <h6 id="tables-and-datagrids">Tables and Datagrids</h6>
+
+    <div class="row cozy-sm">
+        <div class="col-xs-12 col-md-5">
+            <img src="/assets/images/documentation/app-layout/tables.png?1481674789140619000" alt="Tables and Datagrids" />
+        </div>
+        <div class="col-xs-12 col-md-7">
+            <div>
+                <a routerLink="/documentation/tables">Tables</a> and datagrids are for good for managing large amounts of data. These layouts work well when users need to compare data and perform batch operations.
+            </div>
+            <p>
+                A table is a static view. A datagrid provides users flexibility in viewing the data, including filtering and sorting.
+            </p>
+            <p>
+                Complex tables and datagrids work best on larger screens.
+            </p>
+        </div>
+    </div>
+
+    <h6 id="forms">Forms</h6>
+
+    <div class="row cozy-sm">
+        <div class="col-xs-12 col-md-5">
+            <img src="/assets/images/documentation/app-layout/forms.png?1481674789140619000" alt="Forms" />
+        </div>
+        <div class="col-xs-12 col-md-7">
+            <div>
+                <a routerLink="/documentation/forms">Forms</a> are for collecting data from users. Forms are comprised of other components, including labels, input fields, labels, checkboxes, radio buttons, and text.
+            </div>
+            <p>
+                A benefit of a form is that users can see what information they must provide. Conversely, too many fields can discourage the user.
+            </p>
+            <p>Inline forms are better than modals in cases where you don't want to block users from performing other actions.</p>
+        </div>
+    </div>
+
+    <h6 id="tabs">Tabs</h6>
+
+    <div class="row cozy-sm">
+        <div class="col-xs-12 col-md-5">
+            <img src="/assets/images/documentation/app-layout/tabs.png?1481674789140619000" alt="Tabs" />
+        </div>
+        <div class="col-xs-12 col-md-7">
+            <div>
+                <a routerLink="/documentation/tabs">Tabs</a> appear in a single, non-scrollable row, at the top of the content area. They are good for breaking content into separate, related views.
+            </div>
+            <p>
+                Tabs are not appropriate if users need to compare data across views.
+            </p>
+        </div>
+    </div>
+
+    <h6 id="white-space-and-typography">White Space and Typography</h6>
+
+    <div class="row cozy-sm">
+        <div class="col-xs-12 col-md-5">
+            <img src="/assets/images/documentation/app-layout/typography.png?1481674789140619000" alt="White Space and Typography" />
+        </div>
+        <div class="col-xs-12 col-md-7">
+            <div>
+                White space and <a routerLink="/documentation/typography">typography</a> are important elements in conveying hierarchy. These elements direct users to what they should view next and make the content and data easier to parse. They also
+                helps bring consistency to an app.
+            </div>
+        </div>
+    </div>
+
+    <h6 id="button-placement">Button Placement</h6>
+
+    <p>In the content area, buttons are left-aligned, with the primary button in the leftmost position. This placement supports the F-pattern layout.</p>
+
+    <div class="row cozy-sm">
+        <div class="col-xs-12 col-md-5">
+            <img src="/assets/images/documentation/app-layout/do_button_alignment.png?1481674789140619000" alt="Buttons align left in content area" />
+            <p><b><font color="#318700">Do.</font> </b> Left-alignment puts buttons closest to the content.
+            </p>
+        </div>
+        <div class="col-xs-12 col-md-7">
+            <div>
+                <img src="/assets/images/documentation/app-layout/dont_button_alignment.png?1481674789140619000" alt="Buttons do not align right in content area" />
+                <p><b><font color="#E62700">Don't.</font> </b>On the right, buttons might appear separate from content.</p>
+            </div>
+        </div>
+    </div>
+
+    <h4 id="using-vertical-rhythm-for-layout">Using Vertical Rhythm for Layout</h4>
+
+    <p>Vertical rhythm is the repetition of spatial relationships in a design. A consistent rhythm gives elements a uniform and balanced placement in a design. The more consistent the design, the easier it is for users to read and understand.</p>
+
+    <h6 id="the-clarity-baseline-is-24px">The Clarity Baseline is 24px</h6>
+
+    <p>All elements in Clarity are built in terms of 24px:</p>
+
     <ul class="list">
-      <li>Content Area</li>
-      <li><a href="/clarity/documentation/sidenav">Sidenav</a></li>
+        <li>The height of all components and text elements is in multiples of 24px.</li>
+        <li>The vertical white space between elements is also in multiples of 24px.</li>
     </ul>
-  </div>
 
-  <clr-layout-all-demo></clr-layout-all-demo>
+    <p><img src="/assets/images/documentation/app-layout/24_baseline.png?1481674789140619000" alt="24px Baseline" /></p>
 
-  <h3 id="guidelines">Basic Structure</h3>
+    <h6 id="repeat-24px-in-your-layout">Repeat 24px in Your Layout</h6>
 
-  <p>Two constants of an app built in Clarity are the header and content area. These are the blocks upon which you build your app model.</p>
+    <p>Calculate the vertical margins and padding between elements using the Clarity baseline. A multiple of 24px can be a whole or half-ratio. Common numbers include:</p>
 
-  <div class="row cozy-sm">
-    <div class="col-xs-12 col-md-5">
-      <img src="/assets/images/documentation/app-layout/header_contentarea.png?1481674789140619000" alt="Header and Content Area" />
-    </div>
-    <div class="col-xs-12 col-md-7">
-      <h5 style="margin-top:0">Header</h5>
-      The <a href="/clarity/documentation/header">header</a> is for branding and app-level elements such as navigation, search, and account settings.
-
-      <h5>Content Area</h5>
-      The content area is where users focus their attention most of the time, gathering information and performing tasks–it is the canvas for your application. As the largest portion of your app, the content area is always visible.
-    </div>
-  </div>
-
-  <h3 id="layout-1">Layout</h3>
-  <p>Your layout should reflect the information or workflow of the selected <a href="/clarity/documentation/navigation">navigation</a>. When laying out the content, keep the following in mind:</p>
-
-  <ul class="list">
-    <li>The flow of content–how to create a hierarchy and layout that draws attention to the areas of importance</li>
-    <li>The importance of designing to the <a href="/clarity/documentation/grid">grid</a></li>
-    <li>How to aid users in completing their tasks</li>
-    <li>How to handle large amounts of data</li>
-    <li>Responsive design (if that is part of your product’s goals)</li>
-  </ul>
-
-  <h5 id="common-layout-patterns">Common Layout Patterns</h5>
-
-  <p>Content can consist of any of the <a href="/clarity/documentation/">Clarity components</a>, or no components and just information.  Following are common layout patterns and recommended usage.
-    For information on navigation components, header, subnav, and sidenav, see <a href="/clarity/documentation/navigation">Navigation</a>.</p>
-
-  <h6 id="cards">Cards</h6>
-
-  <div class="row cozy-sm">
-    <div class="col-xs-12 col-md-5">
-      <img src="/assets/images/documentation/app-layout/cards.png?1481674789140619000" alt="Cards" />
-    </div>
-    <div class="col-xs-12 col-md-7">
-      <div>
-        <a href="/clarity/documentation/cards">Cards</a> are for presenting high-level information and guiding users to related actions and details. Cards might include a combination of text, images, and data visualizations.
-      </div>
-      <p>
-        Benefits of using cards include:
-      </p>
-      <ul class="list">
-        <li>Ability to see data in a collection</li>
-        <li>Facilitates scanning of information</li>
-        <li>Works well across platforms</li>
-      </ul>
-    </div>
-  </div>
-
-  <h6 id="tables-and-datagrids">Tables and Datagrids</h6>
-
-  <div class="row cozy-sm">
-    <div class="col-xs-12 col-md-5">
-      <img src="/assets/images/documentation/app-layout/tables.png?1481674789140619000" alt="Tables and Datagrids" />
-    </div>
-    <div class="col-xs-12 col-md-7">
-      <div>
-        <a href="/clarity/documentation/tables">Tables</a> and datagrids are for good for managing large amounts of data.  These layouts work well when users need to compare data and perform batch operations.
-      </div>
-      <p>
-        A table is a static view.  A datagrid provides users flexibility in viewing the data, including filtering and sorting.
-      </p>
-      <p>
-        Complex tables and datagrids work best on larger screens.
-      </p>
-    </div>
-  </div>
-
-  <h6 id="forms">Forms</h6>
-
-  <div class="row cozy-sm">
-    <div class="col-xs-12 col-md-5">
-      <img src="/assets/images/documentation/app-layout/forms.png?1481674789140619000" alt="Forms" />
-    </div>
-    <div class="col-xs-12 col-md-7">
-      <div>
-        <a href="/clarity/documentation/forms">Forms</a> are for collecting data from users.  Forms are comprised of other components, including labels, input fields, labels, checkboxes, radio buttons, and text.
-      </div>
-      <p>
-        A benefit of a form is that users can see what information they must provide. Conversely, too many fields can discourage the user.
-      </p>
-      <p>Inline forms are better than modals in cases where you don't want to block users from performing other actions.</p>
-    </div>
-  </div>
-
-  <h6 id="tabs">Tabs</h6>
-
-  <div class="row cozy-sm">
-    <div class="col-xs-12 col-md-5">
-      <img src="/assets/images/documentation/app-layout/tabs.png?1481674789140619000" alt="Tabs" />
-    </div>
-    <div class="col-xs-12 col-md-7">
-      <div>
-        <a href="/clarity/documentation/tabs">Tabs</a> appear in a single, non-scrollable row, at the top of the content area.  They are good for breaking content into separate, related views.
-      </div>
-      <p>
-        Tabs are not appropriate if users need to compare data across views.
-      </p>
-    </div>
-  </div>
-
-  <h6 id="white-space-and-typography">White Space and Typography</h6>
-
-  <div class="row cozy-sm">
-    <div class="col-xs-12 col-md-5">
-      <img src="/assets/images/documentation/app-layout/typography.png?1481674789140619000" alt="White Space and Typography" />
-    </div>
-    <div class="col-xs-12 col-md-7">
-      <div>
-        White space and <a href="/clarity/documentation/typography">typography</a> are important elements in conveying hierarchy.  These elements direct users to what they should view next and make the content and data easier to parse. They also helps bring consistency to an app.
-      </div>
-    </div>
-  </div>
-
-  <h6 id="button-placement">Button Placement</h6>
-
-  <p>In the content area, buttons are left-aligned, with the primary button in the leftmost position.  This placement supports the F-pattern layout.</p>
-
-  <div class="row cozy-sm">
-    <div class="col-xs-12 col-md-5">
-      <img src="/assets/images/documentation/app-layout/do_button_alignment.png?1481674789140619000" alt="Buttons align left in content area" />
-      <p><b><font color="#318700">Do.</font> </b> Left-alignment puts buttons closest to the content.
-      </p>
-    </div>
-    <div class="col-xs-12 col-md-7">
-      <div>
-        <img src="/assets/images/documentation/app-layout/dont_button_alignment.png?1481674789140619000" alt="Buttons do not align right in content area" />
-        <p><b><font color="#E62700">Don't.</font> </b>On the right, buttons might appear separate from content.</p>
-      </div>
-    </div>
-  </div>
-
-  <h4 id="using-vertical-rhythm-for-layout">Using Vertical Rhythm for Layout</h4>
-
-  <p>Vertical rhythm is the repetition of spatial relationships in a design.  A consistent rhythm gives elements a uniform and balanced placement in a design.  The more consistent the design, the easier it is for users to read and understand.</p>
-
-  <h6 id="the-clarity-baseline-is-24px">The Clarity Baseline is 24px</h6>
-
-  <p>All elements in Clarity are built in terms of 24px:</p>
-
-  <ul class="list">
-    <li>The height of all components and text elements is in multiples of 24px.</li>
-    <li>The vertical white space between elements is also in multiples of 24px.</li>
-  </ul>
-
-  <p><img src="/assets/images/documentation/app-layout/24_baseline.png?1481674789140619000" alt="24px Baseline" /></p>
-
-  <h6 id="repeat-24px-in-your-layout">Repeat 24px in Your Layout</h6>
-
-  <p>Calculate the vertical margins and padding between elements using the Clarity baseline.  A multiple of 24px can be a whole or half-ratio. Common numbers include:</p>
-
-  <p>6 px, 12px, 18px, 24px, 30px, 36px, 42px, 48px, 54px, 60px, 66px, 72px</p>
+    <p>6 px, 12px, 18px, 24px, 30px, 36px, 42px, 48px, 54px, 60px, 66px, 72px</p>
 </article>

--- a/src/pages/documentation/badges.html
+++ b/src/pages/documentation/badges.html
@@ -1,36 +1,36 @@
+<article>
+    <h5 class="component-summary" id="a-badge-overlays-a-count-of-items-on-another-component-such-as-a-menu-or-label">A badge overlays a count of items on another component, such as a menu or label.</h5>
 
-<article><h5 class="component-summary" id="a-badge-overlays-a-count-of-items-on-another-component-such-as-a-menu-or-label">A badge overlays a count of items on another component, such as a menu or label.</h5>
+    <h6 id="badges-color-options">1. Badges (Color Options)</h6>
 
-  <h6 id="badges-color-options">1. Badges (Color Options)</h6>
+    <clr-badge-colors-demo></clr-badge-colors-demo>
 
-  <clr-badge-colors-demo></clr-badge-colors-demo>
+    <h6 id="status-badges">2. Status Badges</h6>
 
-  <h6 id="status-badges">2. Status Badges</h6>
+    <clr-badge-statuses-demo></clr-badge-statuses-demo>
 
-  <clr-badge-statuses-demo></clr-badge-statuses-demo>
+    <h3 id="guidelines">Usage</h3>
 
-  <h3 id="guidelines">Usage</h3>
+    <p>Use a badge to show a tally or other quantity. For example, you might overlay a badge on a <a routerLink="/documentation/labels">label</a> or menu item to show a count of that item.</p>
 
-  <p>Use a badge to show a tally or other quantity. For example, you might overlay a badge on a <a href="/clarity/documentation/labels">label</a> or menu item to show a count of that item.</p>
+    <h4 id="placement">Placement</h4>
 
-  <h4 id="placement">Placement</h4>
+    <ul class="list">
+        <li>Place the badge to the right of the object that it qualifies.</li>
+        <li>To avoid ambiguity, use only one badge per object.</li>
+    </ul>
 
-  <ul class="list">
-    <li>Place the badge to the right of the object that it qualifies.</li>
-    <li>To avoid ambiguity, use only one badge per object.</li>
-  </ul>
+    <h4 id="numbering">Numbering</h4>
 
-  <h4 id="numbering">Numbering</h4>
+    <ul class="list">
+        <li>Use integers only.</li>
+        <li>If the count exceeds 99, use “99+.”</li>
+    </ul>
 
-  <ul class="list">
-    <li>Use integers only.</li>
-    <li>If the count exceeds 99, use “99+.”</li>
-  </ul>
+    <h4 id="color">Color</h4>
 
-  <h4 id="color">Color</h4>
-
-  <ul class="list">
-    <li>For most badges, use the color palette specific to badges and labels.</li>
-    <li>For badges that indicate success, warning, or error, use Stoplight colors.</li>
-  </ul>
+    <ul class="list">
+        <li>For most badges, use the color palette specific to badges and labels.</li>
+        <li>For badges that indicate success, warning, or error, use Stoplight colors.</li>
+    </ul>
 </article>

--- a/src/pages/documentation/buttons.html
+++ b/src/pages/documentation/buttons.html
@@ -1,177 +1,176 @@
+<article>
+    <h5 class="component-summary" id="use-claritys-buttons-to-submit-forms-or-initiate-actions-in-modals-wizards-or-other-interactive-blocks-of-content">Use Clarity’s buttons to submit forms or initiate actions in modals, wizards, or other interactive blocks of content.</h5>
 
-<article><h5 class="component-summary" id="use-claritys-buttons-to-submit-forms-or-initiate-actions-in-modals-wizards-or-other-interactive-blocks-of-content">Use Clarity’s buttons to submit forms or initiate actions in modals, wizards, or other interactive blocks of content.</h5>
+    <h3 id="styles">Styles</h3>
 
-  <h3 id="styles">Styles</h3>
+    <p>Clarity defines three button styles:</p>
 
-  <p>Clarity defines three button styles:</p>
+    <ul class="list">
+        <li><strong>Solid.</strong> A solid background with light text. These buttons are prominent on the page.</li>
+        <li><strong>Outline.</strong> A transparent background with colored border and text. On hover, the button fills with color.</li>
+        <li><strong>Flat.</strong> Text in Action Blue that fills with a button shape on hover.</li>
+    </ul>
 
-  <ul class="list">
-    <li><strong>Solid.</strong> A solid background with light text. These buttons are prominent on the page.</li>
-    <li><strong>Outline.</strong> A transparent background with colored border and text. On hover, the button fills with color.</li>
-    <li><strong>Flat.</strong> Text in Action Blue that fills with a button shape on hover.</li>
-  </ul>
+    <clr-buttons-demo-real-button class="clrweb-button-demo"></clr-buttons-demo-real-button>
 
-  <clr-buttons-demo-real-button class="clrweb-button-demo"></clr-buttons-demo-real-button>
+    <h3 id="types">Types</h3>
 
-  <h3 id="types">Types</h3>
+    <clr-buttons-demo-primary-button class="clrweb-button-demo"></clr-buttons-demo-primary-button>
 
-  <clr-buttons-demo-primary-button class="clrweb-button-demo"></clr-buttons-demo-primary-button>
+    <clr-buttons-demo-secondary-button class="clrweb-button-demo indent"></clr-buttons-demo-secondary-button>
 
-  <clr-buttons-demo-secondary-button class="clrweb-button-demo indent"></clr-buttons-demo-secondary-button>
+    <clr-buttons-demo-tertiary-button class="clrweb-button-demo indent"></clr-buttons-demo-tertiary-button>
 
-  <clr-buttons-demo-tertiary-button class="clrweb-button-demo indent"></clr-buttons-demo-tertiary-button>
+    <h3 id="states">States</h3>
 
-  <h3 id="states">States</h3>
+    <clr-buttons-demo-button-states class="clrweb-button-demo"></clr-buttons-demo-button-states>
 
-  <clr-buttons-demo-button-states class="clrweb-button-demo"></clr-buttons-demo-button-states>
+    <h3 id="sizes">Sizes</h3>
 
-  <h3 id="sizes">Sizes</h3>
+    <clr-buttons-demo-button-sizes class="clrweb-button-demo"></clr-buttons-demo-button-sizes>
 
-  <clr-buttons-demo-button-sizes class="clrweb-button-demo"></clr-buttons-demo-button-sizes>
+    <h3 id="inverse">Inverse</h3>
 
-  <h3 id="inverse">Inverse</h3>
+    <clr-buttons-demo-inverse-button class="clrweb-button-demo"></clr-buttons-demo-inverse-button>
 
-  <clr-buttons-demo-inverse-button class="clrweb-button-demo"></clr-buttons-demo-inverse-button>
+    <h3 id="guidelines">Using Buttons</h3>
 
-  <h3 id="guidelines">Using Buttons</h3>
+    <h4 id="solid-outline-and-flat">Solid, outline, and flat</h4>
 
-  <h4 id="solid-outline-and-flat">Solid, outline, and flat</h4>
-
-  <div class="row buttons-modal-gfx">
-    <div class="col-xs-12 col-sm-2">
-      <button type="submit" class="btn btn-primary">Solid</button>
+    <div class="row buttons-modal-gfx">
+        <div class="col-xs-12 col-sm-2">
+            <button type="submit" class="btn btn-primary">Solid</button>
+        </div>
+        <div class="col-xs-12 col-sm-10">
+            For the preferred or default action. One solid button per component.
+        </div>
     </div>
-    <div class="col-xs-12 col-sm-10">
-      For the preferred or default action. One solid button per component.
+    <div class="row buttons-modal-gfx">
+        <div class="col-xs-12 col-sm-2">
+            <button type="submit" class="btn btn-outline">Outline</button>
+        </div>
+        <div class="col-xs-12 col-sm-10">
+            For a neutral or negative action, next to a solid button, or when actions are equivalent.
+        </div>
     </div>
-  </div>
-  <div class="row buttons-modal-gfx">
-    <div class="col-xs-12 col-sm-2">
-      <button type="submit" class="btn btn-outline">Outline</button>
+    <div class="row buttons-modal-gfx">
+        <div class="col-xs-12 col-sm-2">
+            <button type="submit" class="btn btn-link">Flat</button>
+        </div>
+        <div class="col-xs-12 col-sm-10">
+            For lower priority actions (More Information or Don't Remind Me Again). Also when actions are equivalent and space is limited (toolbars and cards).
+        </div>
     </div>
-    <div class="col-xs-12 col-sm-10">
-      For a neutral or negative action, next to a solid button, or when actions are equivalent.
-    </div>
-  </div>
-  <div class="row buttons-modal-gfx">
-    <div class="col-xs-12 col-sm-2">
-      <button type="submit" class="btn btn-link">Flat</button>
-    </div>
-    <div class="col-xs-12 col-sm-10">
-      For lower priority actions (More Information or Don't Remind Me Again).
-      Also when actions are equivalent and space is limited (toolbars and cards).
-    </div>
-  </div>
 
-  <h4 id="alignment-is-container-dependent">Alignment is container dependent</h4>
+    <h4 id="alignment-is-container-dependent">Alignment is container dependent</h4>
 
-  <p>Spatial relationships with other elements in the component or space determine button placement.</p>
+    <p>Spatial relationships with other elements in the component or space determine button placement.</p>
 
-  <div class="row buttons-modal-gfx">
-    <div class="col-xs-12 col-sm-2">
-      <a href="/clarity/documentation/modals">Modals</a>
+    <div class="row buttons-modal-gfx">
+        <div class="col-xs-12 col-sm-2">
+            <a routerLink="/documentation/modals">Modals</a>
+        </div>
+        <div class="col-xs-12 col-sm-10">
+            Right-aligned
+        </div>
     </div>
-    <div class="col-xs-12 col-sm-10">
-      Right-aligned
+    <div class="row buttons-modal-gfx">
+        <div class="col-xs-12 col-sm-2">
+            <a routerLink="/documentation/wizards">Wizards</a>
+        </div>
+        <div class="col-xs-12 col-sm-10">
+            Right-aligned
+        </div>
     </div>
-  </div>
-  <div class="row buttons-modal-gfx">
-    <div class="col-xs-12 col-sm-2">
-      <a href="/clarity/documentation/wizards">Wizards</a>
+    <div class="row buttons-modal-gfx">
+        <div class="col-xs-12 col-sm-2">
+            <a routerLink="/documentation//cards">Cards</a>
+        </div>
+        <div class="col-xs-12 col-sm-10">
+            Left-aligned
+        </div>
     </div>
-    <div class="col-xs-12 col-sm-10">
-      Right-aligned
+    <div class="row buttons-modal-gfx">
+        <div class="col-xs-12 col-sm-2">
+            <a routerLink="/documentation/app-layout">Content area</a>
+        </div>
+        <div class="col-xs-12 col-sm-10">
+            Left-aligned
+        </div>
     </div>
-  </div>
-  <div class="row buttons-modal-gfx">
-    <div class="col-xs-12 col-sm-2">
-      <a href="/clarity/documentation//cards">Cards</a>
-    </div>
-    <div class="col-xs-12 col-sm-10">
-      Left-aligned
-    </div>
-  </div>
-  <div class="row buttons-modal-gfx">
-    <div class="col-xs-12 col-sm-2">
-      <a href="/clarity/documentation/app-layout">Content area</a>
-    </div>
-    <div class="col-xs-12 col-sm-10">
-      Left-aligned
-    </div>
-  </div>
 
-  <h4 id="info-success-and-danger-indicate-action-severity">Info, success, and danger indicate action severity</h4>
+    <h4 id="info-success-and-danger-indicate-action-severity">Info, success, and danger indicate action severity</h4>
 
-  <div class="row buttons-modal-gfx">
-    <div class="col-xs-12 col-sm-2">
-      <button type="submit" class="btn btn-outline">Info</button>
+    <div class="row buttons-modal-gfx">
+        <div class="col-xs-12 col-sm-2">
+            <button type="submit" class="btn btn-outline">Info</button>
+        </div>
+        <div class="col-xs-12 col-sm-10">
+            For displaying more detailed information. Typically an outline button.
+        </div>
     </div>
-    <div class="col-xs-12 col-sm-10">
-      For displaying more detailed information. Typically an outline button.
+    <div class="row buttons-modal-gfx">
+        <div class="col-xs-12 col-sm-2">
+            <button type="submit" class="btn btn-success">Success</button>
+        </div>
+        <div class="col-xs-12 col-sm-10">
+            For the last step (and preferred action) in a multi-step workflow.
+        </div>
     </div>
-  </div>
-  <div class="row buttons-modal-gfx">
-    <div class="col-xs-12 col-sm-2">
-      <button type="submit" class="btn btn-success">Success</button>
+    <div class="row buttons-modal-gfx">
+        <div class="col-xs-12 col-sm-2">
+            <button type="submit" class="btn btn-danger">Danger</button>
+        </div>
+        <div class="col-xs-12 col-sm-10">
+            For a warning or destructive action, such as Delete. Although warning messages are often in yellow, this color does not work well for buttons because the light-colored text is not accessible against a yellow background.
+        </div>
     </div>
-    <div class="col-xs-12 col-sm-10">
-      For the last step (and preferred action) in a multi-step workflow.
-    </div>
-  </div>
-  <div class="row buttons-modal-gfx">
-    <div class="col-xs-12 col-sm-2">
-      <button type="submit" class="btn btn-danger">Danger</button>
-    </div>
-    <div class="col-xs-12 col-sm-10">
-      For a warning or destructive action, such as Delete. Although warning messages are often in yellow, this color does not work well for buttons because the light-colored text is not accessible against a yellow background.
-    </div>
-  </div>
 
-  <h4 id="size-is-location-dependent">Size is location dependent</h4>
+    <h4 id="size-is-location-dependent">Size is location dependent</h4>
 
-  <div class="row buttons-modal-gfx">
-    <div class="col-xs-12 col-sm-2">
-      <button type="submit" class="btn btn-primary">
+    <div class="row buttons-modal-gfx">
+        <div class="col-xs-12 col-sm-2">
+            <button type="submit" class="btn btn-primary">
         Default
       </button>
+        </div>
+        <div class="col-xs-12 col-sm-10">
+            Use the default height of 36 pixels in modals, wizards, and in the content area.
+        </div>
     </div>
-    <div class="col-xs-12 col-sm-10">
-      Use the default height of 36 pixels in modals, wizards, and in the content area.
+    <div class="row buttons-modal-gfx">
+        <div class="col-xs-12 col-sm-2">
+            <button type="submit" class="btn btn-sm">Compact</button>
+        </div>
+        <div class="col-xs-12 col-sm-10">
+            Use the compact button, 24 pixels in height, in datagrids, tables, cards, inline, and other areas not large enough to accommodate the default size.
+        </div>
     </div>
-  </div>
-  <div class="row buttons-modal-gfx">
-    <div class="col-xs-12 col-sm-2">
-      <button type="submit" class="btn btn-sm">Compact</button>
-    </div>
-    <div class="col-xs-12 col-sm-10">
-      Use the compact button, 24 pixels in height, in datagrids, tables, cards, inline, and other areas not large enough to accommodate the default size.
-    </div>
-  </div>
 
-  <h4 id="the-block-button">The block button</h4>
+    <h4 id="the-block-button">The block button</h4>
 
-  <p>A block button occupies the full width of its container.  A common use of this button is in the Login screen.</p>
+    <p>A block button occupies the full width of its container. A common use of this button is in the Login screen.</p>
 
-  <div class="row buttons-modal-gfx">
-    <div class="col-xs">
-                    <span>
+    <div class="row buttons-modal-gfx">
+        <div class="col-xs">
+            <span>
         <p align="center"><button type="submit" class="btn btn-primary btn-block">Block</button></p>
         </span>
 
+        </div>
     </div>
-  </div>
 
-  <h4 id="inverse-formatting-is-for-a-secondary-outline-button">Inverse formatting is for a secondary, outline button</h4>
+    <h4 id="inverse-formatting-is-for-a-secondary-outline-button">Inverse formatting is for a secondary, outline button</h4>
 
-  <p>For information about when to use inverse styling, see the <a href="/clarity/documentation/color">Color</a> documentation.</p>
+    <p>For information about when to use inverse styling, see the <a routerLink="/documentation/color">Color</a> documentation.</p>
 
-  <h4 id="clear-and-concise-labels">Clear and concise labels</h4>
+    <h4 id="clear-and-concise-labels">Clear and concise labels</h4>
 
-  <p>Use a verb or verb phrase that describes the button’s action. Limit labels to three words and avoid long words.</p>
+    <p>Use a verb or verb phrase that describes the button’s action. Limit labels to three words and avoid long words.</p>
 
-  <p>Buttons labels use uppercase text.  Buttons can be quite small in an enterprise application, and research shows that uppercase letters are easier to read at smaller font sizes.</p>
+    <p>Buttons labels use uppercase text. Buttons can be quite small in an enterprise application, and research shows that uppercase letters are easier to read at smaller font sizes.</p>
 
-  <p>Labels for normal-sized buttons range from 10 to 12 points.  Smaller buttons, such as those in datagrids, headers, and navigation components, might use as small as 8 points.</p>
+    <p>Labels for normal-sized buttons range from 10 to 12 points. Smaller buttons, such as those in datagrids, headers, and navigation components, might use as small as 8 points.</p>
 
-  <!--See [Letter Case and Text Legibility in Normal and Low Vision](http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2016788/).-->
+    <!--See [Letter Case and Text Legibility in Normal and Low Vision](http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2016788/).-->
 </article>

--- a/src/pages/documentation/cards.html
+++ b/src/pages/documentation/cards.html
@@ -1,154 +1,155 @@
+<article>
+    <h5 class="component-summary" id="a-card-presents-high-level-information-and-can-guide-the-user-toward-related-actions-and-details">A card presents high-level information and can guide the user toward related actions and details.</h5>
 
-<article><h5 class="component-summary" id="a-card-presents-high-level-information-and-can-guide-the-user-toward-related-actions-and-details">A card presents high-level information and can guide the user toward related actions and details.</h5>
+    <h4 id="basic-card">Basic Card</h4>
 
-  <h4 id="basic-card">Basic Card</h4>
+    <p>A <code class="clr-code">.card</code> can contain a <code class="clr-code">.card-header</code>,
+        <code class="clr-code">.card-footer</code>, and one or more <code class="clr-code">.card-block</code>s.</p>
 
-  <p>A <code class="clr-code">.card</code> can contain a <code class="clr-code">.card-header</code>,
-    <code class="clr-code">.card-footer</code>, and one or more <code class="clr-code">.card-block</code>s.</p>
+    <clr-card-layout-demo></clr-card-layout-demo>
 
-  <clr-card-layout-demo></clr-card-layout-demo>
+    <h4 id="clickable-cards">Clickable Cards</h4>
 
-  <h4 id="clickable-cards">Clickable Cards</h4>
+    <p>Adding the <code class="clr-code">.clickable</code> class makes the entire card clickable, initiating a single action.</p>
 
-  <p>Adding the <code class="clr-code">.clickable</code> class makes the entire
-    card clickable, initiating a single action.</p>
+    <clr-card-clickable-demo></clr-card-clickable-demo>
 
-  <clr-card-clickable-demo></clr-card-clickable-demo>
+    <h4 id="images-in-cards">Images in Cards</h4>
 
-  <h4 id="images-in-cards">Images in Cards</h4>
+    <p>A <code class="clr-code">.card-img</code> can be placed anywhere in the card, or it can occupy the entire card.</p>
 
-  <p>A <code class="clr-code">.card-img</code> can be placed anywhere in the card, or it can occupy the entire card.</p>
+    <clr-card-images-demo></clr-card-images-demo>
 
-  <clr-card-images-demo></clr-card-images-demo>
+    <h4 id="dropdowns-in-cards">Dropdowns in Cards</h4>
 
-  <h4 id="dropdowns-in-cards">Dropdowns in Cards</h4>
+    <p>The footer can contain two actions. For more actions, use a
+        <a routerLink="/documentation/dropdowns">dropdown</a>.</p>
 
-  <p>The footer can contain two actions. For more actions, use a
-    <a href="/clarity/documentation/dropdowns">dropdown</a>.</p>
+    <clr-card-dropdown-demo></clr-card-dropdown-demo>
 
-  <clr-card-dropdown-demo></clr-card-dropdown-demo>
+    <h4 id="card-media-block">Card Media Block</h4>
 
-  <h4 id="card-media-block">Card Media Block</h4>
-
-  <p>A <code class="clr-code">.card-media-block</code> combines a <code class="clr-code">.card-media-image</code>
-    and <code class="clr-code">.card-media-description</code>. The description can contain a <code class="clr-code">
+    <p>A <code class="clr-code">.card-media-block</code> combines a <code class="clr-code">.card-media-image</code> and <code class="clr-code">.card-media-description</code>. The description can contain a <code class="clr-code">
       .card-media-title</code> and a <code class="clr-code">.card-media-text</code>.</p>
 
-  <clr-card-media-block-demo></clr-card-media-block-demo>
+    <clr-card-media-block-demo></clr-card-media-block-demo>
 
-  <h4 id="alerts-in-cards">Alerts in Cards</h4>
+    <h4 id="alerts-in-cards">Alerts in Cards</h4>
 
-  <p>Cards can contain <a href="/clarity/documentation/alerts">alerts</a>.</p>
+    <p>Cards can contain <a routerLink="/documentation/alerts">alerts</a>.</p>
 
-  <clr-alert-demo-cards></clr-alert-demo-cards>
+    <clr-alert-demo-cards></clr-alert-demo-cards>
 
-  <h4 id="lists-in-cards">Lists in Cards</h4>
+    <h4 id="lists-in-cards">Lists in Cards</h4>
 
-  <p>Cards can contain <a href="/clarity/documentation/lists">lists</a>.</p>
+    <p>Cards can contain <a routerLink="/documentation/lists">lists</a>.</p>
 
-  <clr-lists-in-cards-demo></clr-lists-in-cards-demo>
+    <clr-lists-in-cards-demo></clr-lists-in-cards-demo>
 
-  <h4 id="list-groups-in-cards">List Groups in Cards</h4>
+    <h4 id="list-groups-in-cards">List Groups in Cards</h4>
 
-  <p>Cards can contain <a href="http://v4-alpha.getbootstrap.com/components/list-group/" target="_blank">Bootstrap 4 List Groups</a>.</p>
+    <p>Cards can contain <a href="http://v4-alpha.getbootstrap.com/components/list-group/" target="_blank">Bootstrap 4 List Groups</a>.</p>
 
-  <clr-list-group-demo></clr-list-group-demo>
+    <clr-list-group-demo></clr-list-group-demo>
 
-  <h4 id="progress-bars-in-cards">Progress Bars in Cards</h4>
+    <h4 id="progress-bars-in-cards">Progress Bars in Cards</h4>
 
-  <p>Cards can contain <a href="/clarity/documentation/progress">progress bars</a>.</p>
+    <p>Cards can contain <a routerLink="/documentation/progress">progress bars</a>.</p>
 
-  <clr-progress-bar-cards-demo></clr-progress-bar-cards-demo>
+    <clr-progress-bar-cards-demo></clr-progress-bar-cards-demo>
 
-  <clr-progress-bar-inline-cards-demo></clr-progress-bar-inline-cards-demo>
+    <clr-progress-bar-inline-cards-demo></clr-progress-bar-inline-cards-demo>
 
-  <h4 id="card-layout">Card Layout</h4>
+    <h4 id="card-layout">Card Layout</h4>
 
-  <p>Clarity recommends using cards in a <a href="/clarity/documentation/grid">grid</a> or a CSS column layout.</p>
+    <p>Clarity recommends using cards in a <a routerLink="/documentation/grid">grid</a> or a CSS column layout.</p>
 
-  <h5 id="cards-in-a-grid">Cards in a Grid</h5>
+    <h5 id="cards-in-a-grid">Cards in a Grid</h5>
 
-  <clr-card-grid-demo></clr-card-grid-demo>
+    <clr-card-grid-demo></clr-card-grid-demo>
 
-  <h5 id="cards-in-css-columns">Cards in CSS Columns</h5>
+    <h5 id="cards-in-css-columns">Cards in CSS Columns</h5>
 
-  <p>Cards can be placed in <code class="clr-code">.card-columns</code>. The default number of columns is three,
-    but can be changed to two or four by adding <code class="clr-code">.card-columns-2</code> or <code class="clr-code">.card-columns-4</code>.</p>
+    <p>Cards can be placed in <code class="clr-code">.card-columns</code>. The default number of columns is three, but can be changed to two or four by adding <code class="clr-code">.card-columns-2</code> or <code class="clr-code">.card-columns-4</code>.</p>
 
-  <clr-card-masonry-demo></clr-card-masonry-demo>
+    <clr-card-masonry-demo></clr-card-masonry-demo>
 
-  <h3 id="guidelines">Usage</h3>
+    <h3 id="guidelines">Usage</h3>
 
-  <p>Example use cases for cards include:</p>
+    <p>Example use cases for cards include:</p>
 
-  <ul class="list">
-    <li>Presenting objects, services, or content summaries while  providing entry points to more detail</li>
-    <li>Representing applications and initiating actions, such as download</li>
-    <li>Displaying metrics</li>
-  </ul>
+    <ul class="list">
+        <li>Presenting objects, services, or content summaries while providing entry points to more detail</li>
+        <li>Representing applications and initiating actions, such as download</li>
+        <li>Displaying metrics</li>
+    </ul>
 
-  <h3 id="content----keep-it-simple">Content – keep it simple</h3>
+    <h3 id="content----keep-it-simple">Content – keep it simple</h3>
 
-  <p>Cards can contain text, images, data visualizations, or multimedia.  Ensure that the content serves your use case. Keep it simple and legible.  Avoid using too much content, overloading the card with too many actions, and placing links within the content.</p>
+    <p>Cards can contain text, images, data visualizations, or multimedia. Ensure that the content serves your use case. Keep it simple and legible. Avoid using too much content, overloading the card with too many actions, and placing links within the content.</p>
 
-  <h3 id="calls-to-action">Calls to action</h3>
+    <h3 id="calls-to-action">Calls to action</h3>
 
-  <p>Place the primary action and a single additional action, if required, in the card footer, left-aligned.  This placement supports the F-pattern layout.</p>
+    <p>Place the primary action and a single additional action, if required, in the card footer, left-aligned. This placement supports the F-pattern layout.</p>
 
-  <p>For more than two actions, use a <a href="/clarity/documentation/dropdowns">dropdown</a>.  Do not place more than eight items in the dropdown menu.</p>
+    <p>For more than two actions, use a <a routerLink="/documentation/dropdowns">dropdown</a>. Do not place more than eight items in the dropdown menu.</p>
 
-  <div class="row buttons-modal-gfx">
-    <div class="col-xs-12 col-sm">
-    <span>
+    <div class="row buttons-modal-gfx">
+        <div class="col-xs-12 col-sm">
+            <span>
         <img src="/assets/images/documentation/buttons/buttons_in_cards_2.png?1481751307980894000" alt="Buttons align left in cards" />
         <p><b><font color="#318700">Do.</font> </b>This card correctly aligns actions on the left.</p>
     </span>
-    </div>
-    <div class="col-xs-12 col-sm">
-    <span>
+        </div>
+        <div class="col-xs-12 col-sm">
+            <span>
         <img src="/assets/images/documentation/buttons/buttons_in_cards_1.png?1481751307980894000" alt="Buttons do not align right in cards" />
         <p><b><font color="#E62700">Don't.</font> </b> Users might not scan to the bottom right of wide cards.</p>
         </span>
+        </div>
     </div>
-  </div>
 
-  <h3 id="clickable-cards----be-predictable">Clickable cards – be predictable</h3>
+    <h3 id="clickable-cards----be-predictable">Clickable cards – be predictable</h3>
 
-  <p>When the entire card is clickable, the resulting action must be an expected outcome.  A common action is to navigate to more details.
-    Not every card need be clickable.
-    <!-- A common action is to navigate to more details. --></p>
+    <p>When the entire card is clickable, the resulting action must be an expected outcome. A common action is to navigate to more details. Not every card need be clickable.
+        <!-- A common action is to navigate to more details. -->
+    </p>
 
-  <h3 id="progress-bars----be-consistent">Progress bars – be consistent</h3>
+    <h3 id="progress-bars----be-consistent">Progress bars – be consistent</h3>
 
-  <div class="row buttons-modal-gfx">
-    <div class="col-xs-12 col-sm">
-    <span>
+    <div class="row buttons-modal-gfx">
+        <div class="col-xs-12 col-sm">
+            <span>
         Progress bars belong at the card top or above the footer,   closest to the triggering action.  Be consistent with progress bar placement within a card group.
     </span>
-    </div>
-    <div class="hidden-xs-down col-sm">
-    <span>
+        </div>
+        <div class="hidden-xs-down col-sm">
+            <span>
          <img src="/assets/images/documentation/cards/card_progress.png?1481751307980894000" />
     </span>
+        </div>
     </div>
-  </div>
 
-  <h3 id="group-cards-by-theme-or-element">Group cards by theme or element</h3>
+    <h3 id="group-cards-by-theme-or-element">Group cards by theme or element</h3>
 
-  <!-- When grouping cards, consider the mental model you want to convey: -->
+    <!-- When grouping cards, consider the mental model you want to convey: -->
 
-  <ul class="list">
-    <li>Homogeneous content facilitates scanning – users  quickly find and compare information of interest.  <!--Objects, applications, and services are typically collected in individual, homogeneous groups.--></li>
-    <li>Content of varying type often shows “the bigger picture.”<!-- --such a collection might show the number of users logged in, recent tasks, alerts, and infrastructure to build.  Cards in heterogeneous groups often don't have associated actions. --></li>
-  </ul>
+    <ul class="list">
+        <li>Homogeneous content facilitates scanning – users quickly find and compare information of interest.
+            <!--Objects, applications, and services are typically collected in individual, homogeneous groups.-->
+        </li>
+        <li>Content of varying type often shows “the bigger picture.”
+            <!-- --such a collection might show the number of users logged in, recent tasks, alerts, and infrastructure to build.  Cards in heterogeneous groups often don't have associated actions. -->
+        </li>
+    </ul>
 
-  <h3 id="use-a-grid-for-card-layout">Use a grid for card layout</h3>
+    <h3 id="use-a-grid-for-card-layout">Use a grid for card layout</h3>
 
-  <p>A grid places cards in fixed rows and columns:  more content in less vertical space means less scrolling. It’s easy for users to scan content in this layout. If in doubt, use the grid.</p>
+    <p>A grid places cards in fixed rows and columns: more content in less vertical space means less scrolling. It’s easy for users to scan content in this layout. If in doubt, use the grid.</p>
 
-  <h3 id="switching-views-cards-and-datagrids">Switching views: cards and datagrids</h3>
+    <h3 id="switching-views-cards-and-datagrids">Switching views: cards and datagrids</h3>
 
-  <p>In homogeneous card groups, consider enabling users to switch between card view and datagrid view. While cards show richer content than a datagrid, a datagrid lists more items at once.</p>
+    <p>In homogeneous card groups, consider enabling users to switch between card view and datagrid view. While cards show richer content than a datagrid, a datagrid lists more items at once.</p>
 
-  <p>Toggles for switching between views go in the upper right of the card group. The card group should be the default view.</p>
+    <p>Toggles for switching between views go in the upper right of the card group. The card group should be the default view.</p>
 </article>

--- a/src/pages/documentation/checkboxes.html
+++ b/src/pages/documentation/checkboxes.html
@@ -1,14 +1,16 @@
+<article>
+    <h5 class="component-summary" id="with-checkboxes-users-can-select-multiple-options-in-a-list-of-options">With checkboxes, users can select multiple options in a list of options.</h5>
 
-<article><h5 class="component-summary" id="with-checkboxes-users-can-select-multiple-options-in-a-list-of-options">With checkboxes, users can select multiple options in a list of options.</h5>
+    <clr-checkboxes-demo></clr-checkboxes-demo>
 
-  <clr-checkboxes-demo></clr-checkboxes-demo>
+    <h3 id="guidelines">Usage</h3>
 
-  <h3 id="guidelines">Usage</h3>
+    <p>
+        Use a checkbox for yes or no choices, for example “Remember me” on the <a routerLink="/documentation/login">login page</a>. For on and off options, use a <a routerLink="/documentation/toggle-switches">toggle switch</a>.
+    </p>
 
-  <p>Use a checkbox for yes or no choices, for example “Remember me” on the <a href="/clarity/documentation/login">login page</a>.  For on and off options, use a <a href="/clarity/documentation/toggle-switches">toggle switch</a>.</p>
-
-  <ul class="list">
-    <li>Checkboxes are best for seven or fewer options.</li>
-    <li>For readability, keep the checkbox label to a single line.</li>
-  </ul>
+    <ul class="list">
+        <li>Checkboxes are best for seven or fewer options.</li>
+        <li>For readability, keep the checkbox label to a single line.</li>
+    </ul>
 </article>

--- a/src/pages/documentation/datagrid.html
+++ b/src/pages/documentation/datagrid.html
@@ -1,49 +1,48 @@
-
 <article>
-  <h5 class="component-summary" id="datagrids-are-for-organizing-large-volumes-of-data-that-users-can-scan-compare-and-perform-actions-on">Datagrids are for organizing large volumes of data that users can scan, compare, and perform actions on.</h5>
+    <h5 class="component-summary" id="datagrids-are-for-organizing-large-volumes-of-data-that-users-can-scan-compare-and-perform-actions-on">Datagrids are for organizing large volumes of data that users can scan, compare, and perform actions on.</h5>
 
-  <clr-datagrid-basic-structure-demo class="clrweb-datagrid-first-demo"></clr-datagrid-basic-structure-demo>
+    <clr-datagrid-basic-structure-demo class="clrweb-datagrid-first-demo"></clr-datagrid-basic-structure-demo>
 
-  <clr-datagrid-custom-rendering-demo></clr-datagrid-custom-rendering-demo>
+    <clr-datagrid-custom-rendering-demo></clr-datagrid-custom-rendering-demo>
 
-  <clr-datagrid-smart-iterator-demo></clr-datagrid-smart-iterator-demo>
+    <clr-datagrid-smart-iterator-demo></clr-datagrid-smart-iterator-demo>
 
-  <clr-datagrid-binding-properties-demo></clr-datagrid-binding-properties-demo>
+    <clr-datagrid-binding-properties-demo></clr-datagrid-binding-properties-demo>
 
-  <clr-datagrid-sorting-demo></clr-datagrid-sorting-demo>
+    <clr-datagrid-sorting-demo></clr-datagrid-sorting-demo>
 
-  <clr-datagrid-filtering-demo></clr-datagrid-filtering-demo>
+    <clr-datagrid-filtering-demo></clr-datagrid-filtering-demo>
 
-  <clr-datagrid-string-filtering-demo></clr-datagrid-string-filtering-demo>
+    <clr-datagrid-string-filtering-demo></clr-datagrid-string-filtering-demo>
 
-  <clr-datagrid-pagination-demo></clr-datagrid-pagination-demo>
+    <clr-datagrid-pagination-demo></clr-datagrid-pagination-demo>
 
-  <clr-datagrid-selection-demo></clr-datagrid-selection-demo>
+    <clr-datagrid-selection-demo></clr-datagrid-selection-demo>
 
-  <clr-datagrid-server-driven-demo></clr-datagrid-server-driven-demo>
+    <clr-datagrid-server-driven-demo></clr-datagrid-server-driven-demo>
 
-  <clr-datagrid-placeholder-demo></clr-datagrid-placeholder-demo>
+    <clr-datagrid-placeholder-demo></clr-datagrid-placeholder-demo>
 
-  <clr-datagrid-full-demo></clr-datagrid-full-demo>
+    <clr-datagrid-full-demo></clr-datagrid-full-demo>
 
-  <h3 id="guidelines">Usage</h3>
+    <h3 id="guidelines">Usage</h3>
 
-  <h4 id="for-structured-content">For Structured Content</h4>
+    <h4 id="for-structured-content">For Structured Content</h4>
 
-  <p>Datagrids work best for structured, homogeneous content, where each object has the same attributes.  When common attributes are directly aligned in columns, users can quickly scan and compare them.</p>
+    <p>Datagrids work best for structured, homogeneous content, where each object has the same attributes. When common attributes are directly aligned in columns, users can quickly scan and compare them.</p>
 
-  <p>For data sets with a blend of text, images, and data visualizations, or content with mixed formatting, <a href="/clarity/documentation/cards">cards</a> offer a better layout.</p>
+    <p>For data sets with a blend of text, images, and data visualizations, or content with mixed formatting, <a routerLink="/documentation/cards">cards</a> offer a better layout.</p>
 
-  <h4 id="for-large-volumes-of-data">For Large Volumes of Data</h4>
+    <h4 id="for-large-volumes-of-data">For Large Volumes of Data</h4>
 
-  <p>A datagrid is well-suited for presenting large volumes of data that don’t fit on one page.  Users can filter and sort the data according to preference.</p>
+    <p>A datagrid is well-suited for presenting large volumes of data that don’t fit on one page. Users can filter and sort the data according to preference.</p>
 
-  <p>For smaller amounts of data (10 to 20 lines), datagrids are a relatively heavy component.  Use datagrids if:</p>
+    <p>For smaller amounts of data (10 to 20 lines), datagrids are a relatively heavy component. Use datagrids if:</p>
 
-  <ul>
-    <li>The data set will grow</li>
-    <li>Users need search, filter, or batch operations</li>
-  </ul>
+    <ul>
+        <li>The data set will grow</li>
+        <li>Users need search, filter, or batch operations</li>
+    </ul>
 
-  <p>For a smaller volume of data, use a <a href="/clarity/documentation/tables">table</a>.  Tables are a lighter-weight solution with a static view.</p>
+    <p>For a smaller volume of data, use a <a routerLink="/documentation/tables">table</a>. Tables are a lighter-weight solution with a static view.</p>
 </article>

--- a/src/pages/documentation/dropdowns.html
+++ b/src/pages/documentation/dropdowns.html
@@ -1,131 +1,133 @@
+<article>
+    <h5 class="component-summary" id="a-dropdown-menu-lists-actions-that-users-can-perform-within-an-application-or-on-a-selected-object">A dropdown menu lists actions that users can perform within an application or on a selected object.</h5>
 
-<article><h5 class="component-summary" id="a-dropdown-menu-lists-actions-that-users-can-perform-within-an-application-or-on-a-selected-object">A dropdown menu lists actions that users can perform within an application or on a selected object.</h5>
+    <h6 id="dropdown">.dropdown:</h6>
 
-  <h6 id="dropdown">.dropdown:</h6>
+    <p>This class is a wrapper class around the <code>.dropdown-toggle</code> and the <code>.dropdown-menu</code></p>
 
-  <p>This class is a wrapper class around the <code>.dropdown-toggle</code> and the <code>.dropdown-menu</code></p>
+    <h6 id="dropdown-toggle">.dropdown-toggle:</h6>
 
-  <h6 id="dropdown-toggle">.dropdown-toggle:</h6>
+    <p>Extend this class on a button, icon or text link clicking on which the dropdown menu will be activated</p>
 
-  <p>Extend this class on a button, icon or text link clicking on which the dropdown menu will be activated</p>
+    <h6 id="dropdown-menu">.dropdown-menu:</h6>
 
-  <h6 id="dropdown-menu">.dropdown-menu:</h6>
+    <p>A required wrapper intended to contain the dropdown menu. Items in the menu should extend the <code>.dropdown-header</code> or <code>.dropdown-item</code> class. <code>.dropdown-divider</code> can be on a block element used to seperate item groups.
+        <code>.active</code> class with <code>.dropdown-item</code> adds a different styling for selected elements. Add the <code>.disabled</code> class to dropdown items to style them as disabled.</p>
 
-  <p>A required wrapper intended to contain the dropdown menu. Items in the menu should extend the <code>.dropdown-header</code> or <code>.dropdown-item</code> class. <code>.dropdown-divider</code> can be on a block element used to seperate item groups. <code>.active</code> class with <code>.dropdown-item</code> adds a different styling for selected elements. Add the <code>.disabled</code> class to dropdown items to style them as disabled.</p>
+    <h6 id="open">.open:</h6>
 
-  <h6 id="open">.open:</h6>
+    <p>A class to open the dropdown menu. Must be applied with <code>.dropdown</code></p>
 
-  <p>A class to open the dropdown menu. Must be applied with <code>.dropdown</code></p>
+    <p>The following classes when extended along with <code>.dropdown</code> will open the menu in the respective directions:</p>
 
-  <p>The following classes when extended along with <code>.dropdown</code> will open the menu in the respective directions:</p>
+    <ul class="list">
+        <li>.bottom-left</li>
+        <li>.bottom-right</li>
+        <li>.top-left</li>
+        <li>.top-right</li>
+        <li>.left-bottom</li>
+        <li>.left-top</li>
+        <li>.right-top</li>
+        <li>.right-bottom</li>
+    </ul>
 
-  <ul class="list">
-    <li>.bottom-left</li>
-    <li>.bottom-right</li>
-    <li>.top-left</li>
-    <li>.top-right</li>
-    <li>.left-bottom</li>
-    <li>.left-top</li>
-    <li>.right-top</li>
-    <li>.right-bottom</li>
-  </ul>
+    <h4 id="examples">Examples</h4>
 
-  <h4 id="examples">Examples</h4>
+    <h6 id="default-dropdown-bottom-left">1. Default dropdown (bottom-left):</h6>
 
-  <h6 id="default-dropdown-bottom-left">1. Default dropdown (bottom-left):</h6>
+    <clr-dropdown-static-default-demo></clr-dropdown-static-default-demo>
 
-  <clr-dropdown-static-default-demo></clr-dropdown-static-default-demo>
+    <h6 id="bottom-right">2. Bottom-right</h6>
 
-  <h6 id="bottom-right">2. Bottom-right</h6>
+    <clr-dropdown-static-positioning-demo></clr-dropdown-static-positioning-demo>
 
-  <clr-dropdown-static-positioning-demo></clr-dropdown-static-positioning-demo>
+    <h6 id="clarity-icon-as-the-dropdown-toggle">3. Clarity icon as the dropdown toggle</h6>
 
-  <h6 id="clarity-icon-as-the-dropdown-toggle">3. Clarity icon as the dropdown toggle</h6>
+    <clr-dropdown-static-icon-toggle-demo></clr-dropdown-static-icon-toggle-demo>
 
-  <clr-dropdown-static-icon-toggle-demo></clr-dropdown-static-icon-toggle-demo>
+    <h6 id="link-button-as-the-dropdown-toggle">4. Link Button as the dropdown toggle</h6>
 
-  <h6 id="link-button-as-the-dropdown-toggle">4. Link Button as the dropdown toggle</h6>
+    <clr-dropdown-static-buttonlink-toggle-demo></clr-dropdown-static-buttonlink-toggle-demo>
 
-  <clr-dropdown-static-buttonlink-toggle-demo></clr-dropdown-static-buttonlink-toggle-demo>
+    <h2 id="angular-component">Angular Component</h2>
 
-  <h2 id="angular-component">Angular Component</h2>
+    <h3 id="summary-of-options">Summary of Options</h3>
 
-  <h3 id="summary-of-options">Summary of Options</h3>
+    <table class="table">
+        <thead>
+            <tr>
+                <th class="left">Input</th>
+                <th class="left hidden-xs-down">Values</th>
+                <th class="left hidden-xs-down">Default</th>
+                <th class="left">Effect</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td class="left">
+                    <b>clrMenuPosition</b>
+                    <div class="hidden-sm-up">Values:<br />Direction classnames</div>
+                    <div class="hidden-sm-up">Default: "bottom-left"</div>
+                </td>
+                <td class="left hidden-xs-down">
+                    CSS dropdown menu direction classnames.
+                </td>
+                <td class="left hidden-xs-down">Bottom-left</td>
+                <td class="left">Sets the direction in which the menu will open.</td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <b>clrCloseMenuOnItemClick</b>
+                    <div class="hidden-sm-up">Type: Boolean</div>
+                    <div class="hidden-sm-up">Default: true</div>
+                </td>
+                <td class="left hidden-xs-down">Boolean</td>
+                <td class="left hidden-xs-down">true</td>
+                <td class="left">If true, the menu will close when a dropdown item is clicked</td>
+            </tr>
+        </tbody>
+    </table>
 
-  <table class="table">
-    <thead>
-    <tr>
-      <th class="left">Input</th>
-      <th class="left hidden-xs-down">Values</th>
-      <th class="left hidden-xs-down">Default</th>
-      <th class="left">Effect</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr>
-      <td class="left">
-        <b>clrMenuPosition</b>
-        <div class="hidden-sm-up">Values:<br />Direction classnames</div>
-        <div class="hidden-sm-up">Default: "bottom-left"</div>
-      </td>
-      <td class="left hidden-xs-down">
-        CSS dropdown menu direction classnames.
-      </td>
-      <td class="left hidden-xs-down">Bottom-left</td>
-      <td class="left">Sets the direction in which the menu will open.</td>
-    </tr>
-    <tr>
-      <td class="left">
-        <b>clrCloseMenuOnItemClick</b>
-        <div class="hidden-sm-up">Type: Boolean</div>
-        <div class="hidden-sm-up">Default: true</div>
-      </td>
-      <td class="left hidden-xs-down">Boolean</td>
-      <td class="left hidden-xs-down">true</td>
-      <td class="left">If true, the menu will close when a dropdown item is clicked</td>
-    </tr>
-    </tbody>
-  </table>
+    <h4 id="example">Example</h4>
 
-  <h4 id="example">Example</h4>
+    <h6 id="clrmenuposition-is-set-to-top-left-default-is-bottom-left">1. clrMenuPosition is set to top-left. Default is bottom-left</h6>
 
-  <h6 id="clrmenuposition-is-set-to-top-left-default-is-bottom-left">1. clrMenuPosition is set to top-left. Default is bottom-left</h6>
+    <clr-dropdown-angular-positioning-demo></clr-dropdown-angular-positioning-demo>
 
-  <clr-dropdown-angular-positioning-demo></clr-dropdown-angular-positioning-demo>
+    <h6 id="clrclosemenuonitemclick-is-set-to-false-default-is-true">2. clrCloseMenuOnItemClick is set to false. Default is true.</h6>
 
-  <h6 id="clrclosemenuonitemclick-is-set-to-false-default-is-true">2. clrCloseMenuOnItemClick is set to false. Default is true.</h6>
+    <clr-dropdown-angular-close-item-false-demo></clr-dropdown-angular-close-item-false-demo>
 
-  <clr-dropdown-angular-close-item-false-demo></clr-dropdown-angular-close-item-false-demo>
+    <h3 id="guidelines">Usage</h3>
 
-  <h3 id="guidelines">Usage</h3>
+    <p>Use a dropdown menu in a header or other area of the UI, such as a column within a datagrid, to present a set of actions. Often, these actions navigate to a new location. For example, you might have a Settings dropdown that changes context to provide
+        logout, account settings, and so on.</p>
 
-  <p>Use a dropdown menu in a header or other area of the UI, such as a column within a datagrid, to present a set of actions.  Often, these actions navigate to a new location.  For example, you might have a Settings dropdown that changes context to provide logout, account settings, and so on.</p>
+    <p>Don’t confuse dropdowns with <a routerLink="/documentation/select-boxes">select boxes</a>, which also present a list of choices. Select boxes are for data input within forms whereas dropdowns are for navigating outside of the existing context.</p>
 
-  <p>Don’t confuse dropdowns with <a href="/clarity/documentation/select-boxes">select boxes</a>, which also present a list of choices.  Select boxes are for data input within forms whereas dropdowns are for navigating outside of the existing context.</p>
+    <h4 id="behavior">Behavior</h4>
 
-  <h4 id="behavior">Behavior</h4>
+    <p>Users open a dropdown by clicking its toggle. By default, selecting a menu item or clicking outside the menu dismisses the menu. You can change this behavior so that the menu remains open on item selection.</p>
 
-  <p>Users open a dropdown by clicking its toggle. By default, selecting a menu item or clicking outside the menu dismisses the menu.  You can change this behavior so that the menu remains open on item selection.</p>
+    <h4 id="placement">Placement</h4>
 
-  <h4 id="placement">Placement</h4>
+    <p>By default, a dropdown opens from the bottom of the toggle, along the left side. You can change the placement by using one of the eight direction classes.</p>
 
-  <p>By default, a dropdown opens from the bottom of the toggle, along the left side.  You can change the placement by using one of the eight direction classes.</p>
+    <h4 id="menu-toggle">Menu Toggle</h4>
 
-  <h4 id="menu-toggle">Menu Toggle</h4>
+    <p>Clarity recommends that you use a button for the toggle. The button can contain either text or an icon.</p>
 
-  <p>Clarity recommends that you use a button for the toggle. The button can contain either text or an icon.</p>
+    <h4 id="menu-items">Menu Items</h4>
 
-  <h4 id="menu-items">Menu Items</h4>
+    <p>Order menu items by usage, except for destructive actions, which belong at the bottom. Keep the text short and concise. Long menu items are truncated from the end and an ellipsis added.</p>
 
-  <p>Order menu items by usage, except for destructive actions, which belong at the bottom.   Keep the text short and concise.  Long menu items are truncated from the end and an ellipsis added.</p>
+    <h4 id="disabled">Disabled</h4>
 
-  <h4 id="disabled">Disabled</h4>
+    <p>Disable a menu item if:</p>
 
-  <p>Disable a menu item if:</p>
-
-  <ul class="list">
-    <li>It can apply in a different context.</li>
-    <li>The user doesn’t have permissions for the action.</li>
-    <li>An appropriate object is not currently selected.</li>
-  </ul>
+    <ul class="list">
+        <li>It can apply in a different context.</li>
+        <li>The user doesn’t have permissions for the action.</li>
+        <li>An appropriate object is not currently selected.</li>
+    </ul>
 </article>

--- a/src/pages/documentation/forms.html
+++ b/src/pages/documentation/forms.html
@@ -1,88 +1,88 @@
+<article>
+    <h5 class="component-summary" id="a-form-is-a-structured-layout-of-related-input-components">A form is a structured layout of related input components.</h5>
 
-<article><h5 class="component-summary" id="a-form-is-a-structured-layout-of-related-input-components">A form is a structured layout of related input components.</h5>
+    <p>A container, often a <code class="clr-code">div</code> with a <code class="clr-code">.form-group</code> classname on it, wraps one or more <code class="clr-code">label</code> and <code class="clr-code">input</code> pairs.</p>
 
-  <p>A container, often a <code class="clr-code">div</code> with a <code class="clr-code">.form-group</code> classname on it, wraps one or more <code class="clr-code">label</code> and <code class="clr-code">input</code> pairs.</p>
+    <h6 id="form-block">.form-block</h6>
 
-  <h6 id="form-block">.form-block</h6>
+    <p class="squish">This is an optional wrapper around one or more .form-group elements (see below). The .form-block element can hold a label element that serves as a title or header for the form-groups within it.</p>
 
-  <p class="squish">This is an optional wrapper around one or more .form-group elements (see below). The .form-block element can hold a label element that serves as a title or header for the form-groups within it.</p>
+    <h6 id="form-group">.form-group</h6>
 
-  <h6 id="form-group">.form-group</h6>
+    <p class="squish">This is a wrapper intended to contain a label and one or more input, .select, .checkbox, .radio, or other form fields.</p>
 
-  <p class="squish">This is a wrapper intended to contain a label and one or more input, .select, .checkbox, .radio, or other form fields.</p>
+    <h6 id="select">.select</h6>
 
-  <h6 id="select">.select</h6>
+    <p class="squish">This is a required wrapper intended to contain a select element and its options. The wrapper is necessary to apply the custom Clarity styles for select boxes.</p>
 
-  <p class="squish">This is a required wrapper intended to contain a select element and its options. The wrapper is necessary to apply the custom Clarity styles for select boxes.</p>
+    <h6 id="radio-checkbox">.radio, .checkbox</h6>
 
-  <h6 id="radio-checkbox">.radio, .checkbox</h6>
+    <p class="squish">This is a required wrapper intended to contain a radio button or a checkbox input followed by a label element. The wrapper is necessary to handle the alignment and spacing of the elements within it.</p>
 
-  <p class="squish">This is a required wrapper intended to contain a radio button or a checkbox input followed by a label element. The wrapper is necessary to handle the alignment and spacing of the elements within it.</p>
+    <h3 id="wrapper-elements">Wrapper Elements</h3>
 
-  <h3 id="wrapper-elements">Wrapper Elements</h3>
+    <p><code class="clr-code">.form-block</code>, <code class="clr-code">.form-group</code>, <code class="clr-code">.select</code>, <code class="clr-code">.radio</code>, and <code class="clr-code">.checkbox</code> wrappers can be placed on any block HTML
+        element. The recommendation is for <code class="clr-code">.form-block</code> classnames to be placed on <code class="clr-code">section</code> or <code class="clr-code">fieldset</code> elements and for <code class="clr-code">.form-group</code>        classnames to be placed on <code class="clr-code">div</code> elements.</p>
 
-  <p><code class="clr-code">.form-block</code>, <code class="clr-code">.form-group</code>, <code class="clr-code">.select</code>, <code class="clr-code">.radio</code>, and <code class="clr-code">.checkbox</code> wrappers can be placed on any block HTML element. The recommendation is for <code class="clr-code">.form-block</code> classnames to be placed on <code class="clr-code">section</code> or <code class="clr-code">fieldset</code> elements and for <code class="clr-code">.form-group</code> classnames to be placed on <code class="clr-code">div</code> elements.</p>
+    <clr-forms-demo-fields></clr-forms-demo-fields>
 
-  <clr-forms-demo-fields></clr-forms-demo-fields>
+    <h3 id="compact-forms">Compact Forms</h3>
 
-  <h3 id="compact-forms">Compact Forms</h3>
+    <p>For forms inside of smaller containers like modals or wizards, the whitespace around form groups and form blocks can be minimized by using the <code>.compact</code> classname.</p>
 
-  <p>For forms inside of smaller containers like modals or wizards, the whitespace around form groups and form blocks can be minimized by using the <code>.compact</code> classname.</p>
+    <clr-forms-compact-demo></clr-forms-compact-demo>
 
-  <clr-forms-compact-demo></clr-forms-compact-demo>
+    <h3 id="forms-in-grid">Forms in Grid</h3>
 
-  <h3 id="forms-in-grid">Forms in Grid</h3>
+    <p>Forms can be used in a grid. Extend the <code class="clr-code">.row</code> class on a <code class="clr-code">.form-group</code> and place the form fields in the grid column classes. To occupy 100% of the column width, extend the <code class="clr-code">.form-control</code>        class on the form field. Resize your browser to see how forms in grids work.</p>
 
-  <p>Forms can be used in a grid. Extend the <code class="clr-code">.row</code> class on a <code class="clr-code">.form-group</code>
-    and place the form fields in the grid column classes. To occupy 100% of the column width, extend the <code class="clr-code">.form-control</code> class on the form field. Resize your browser to see how forms in grids work.</p>
+    <clr-forms-demo-grid></clr-forms-demo-grid>
 
-  <clr-forms-demo-grid></clr-forms-demo-grid>
+    <h3 id="guidelines">Usage</h3>
 
-  <h3 id="guidelines">Usage</h3>
+    <p>Forms guide users through input in a structured, specific order. Forms are comprised of <a routerLink="/documentation/typography">text</a> and input components such as <a routerLink="/documentation/checkboxes">checkboxes</a>, <a routerLink="/documentation/dropdowns">dropdowns</a>,
+        <a routerLink="/documentation/input-fields">input fields</a>, <a routerLink="/documentation/radios">radio buttons</a>, and <a routerLink="/documentation/toggle-switches">toggle switches</a>.</p>
 
-  <p>Forms guide users through input in a structured, specific order.  Forms are comprised of <a href="/clarity/documentation/typography">text</a> and input components such as <a href="/clarity/documentation/checkboxes">checkboxes</a>, <a href="/clarity/documentation/dropdowns">dropdowns</a>, <a href="/clarity/documentation/input-fields">input fields</a>, <a href="/clarity/documentation/radios">radio buttons</a>, and <a href="/clarity/documentation/toggle-switches">toggle switches</a>.</p>
+    <h4 id="minimize-scrolling">Minimize Scrolling</h4>
 
-  <h4 id="minimize-scrolling">Minimize Scrolling</h4>
+    <p>For a form that scrolls several pages, consider organizing the content by:</p>
 
-  <p>For a form that scrolls several pages, consider organizing the content by:</p>
+    <ul class="list">
+        <li>Grouping related fields in a form block with a descriptive label.</li>
+        <li>Progressively revealing more complex or less frequently used data.</li>
+        <li>Dividing content into separate pages in a <a routerLink="/documentation/wizards">wizard</a>.</li>
+    </ul>
 
-  <ul class="list">
-    <li>Grouping related fields in a form block with a descriptive label.</li>
-    <li>Progressively revealing more complex or less frequently used data.</li>
-    <li>Dividing content into separate pages in a <a href="/clarity/documentation/wizards">wizard</a>.</li>
-  </ul>
+    <h4 id="labels">Labels</h4>
 
-  <h4 id="labels">Labels</h4>
+    <p>Labels appear to the left of a component, moving above the component when the user resizes the window to smaller dimensions.</p>
 
-  <p>Labels appear to the left of a component, moving above the component when the user resizes the window to smaller dimensions.</p>
+    <p>Labels use sentence caps, with no ending punctuation.</p>
 
-  <p>Labels use sentence caps, with no ending punctuation.</p>
+    <h4 id="placeholder-text">Placeholder Text</h4>
 
-  <h4 id="placeholder-text">Placeholder Text</h4>
+    <p>Located inside a field, placeholder text can help clarify expected input. Placeholder text disappears when the user types in the field.</p>
 
-  <p>Located inside a field, placeholder text can help clarify expected input.  Placeholder text disappears when the user types in the field.</p>
+    <p>Tip: Use the label to show what information goes in the field and placeholder text as a hint, description, or example format:</p>
 
-  <p>Tip: Use the label to show what information goes in the field and placeholder text as a hint, description, or example format:</p>
+    <p>Label: Airport
+        <br /> Placeholder text: SFO, SJO</p>
 
-  <p>Label: Airport
-    <br />
-    Placeholder text:  SFO, SJO</p>
+    <p>Placeholder text can replace labels only in simple forms with a few easily-understood fields, see the <a routerLink="/documentation/login">login page</a>.</p>
 
-  <p>Placeholder text can replace labels only in simple forms with a few easily-understood fields, see the <a href="/clarity/documentation/login">login page</a>.</p>
+    <h4 id="disabled-fields">Disabled Fields</h4>
 
-  <h4 id="disabled-fields">Disabled Fields</h4>
+    <p>Show a disabled field only if the user can take a reasonable action to enable the component. When disabling a component, also disable all associated elements, such as the component label and explanatory text.</p>
 
-  <p>Show a disabled field only if the user can take a reasonable action to enable the component.  When disabling a component, also disable all associated elements, such as the component label and explanatory text.</p>
+    <h4 id="button-placement">Button Placement</h4>
 
-  <h4 id="button-placement">Button Placement</h4>
+    <p>Button placement depends on form type and where it appears in the UI. See <a routerLink="/documentation/buttons">buttons</a> for guidelines.</p>
 
-  <p>Button placement depends on form type and where it appears in the UI.  See <a href="/clarity/documentation/buttons">buttons</a> for guidelines.</p>
+    <h4 id="validation">Validation</h4>
 
-  <h4 id="validation">Validation</h4>
+    <p>For information on validation, see <a routerLink="/documentation/input-fields">input fields</a>.</p>
 
-  <p>For information on validation, see <a href="/clarity/documentation/input-fields">input fields</a>.</p>
+    <h4 id="focus-and-navigation">Focus and Navigation</h4>
 
-  <h4 id="focus-and-navigation">Focus and Navigation</h4>
-
-  <p>Provide auto focus in the first field by default.  Users can then navigate through the form in a logical sequence.</p>
+    <p>Provide auto focus in the first field by default. Users can then navigate through the form in a logical sequence.</p>
 </article>

--- a/src/pages/documentation/grid.html
+++ b/src/pages/documentation/grid.html
@@ -1,238 +1,233 @@
+<article>
+    <h5 class="component-summary" id="a-grid-provides-a-structure-of-rows-and-columns-for-aligning-content-grids-are-useful-because-they-help-create-a-familiar-and-easily-navigable-structure-for-content">A grid provides a structure of rows and columns for aligning content. Grids are useful because they help create a familiar and easily navigable structure for content.</h5>
 
-<article><h5 class="component-summary" id="a-grid-provides-a-structure-of-rows-and-columns-for-aligning-content-grids-are-useful-because-they-help-create-a-familiar-and-easily-navigable-structure-for-content">A grid provides a structure of rows and columns for aligning content. Grids are useful because they help create a familiar and easily navigable structure for content.</h5>
+    <p>Clarity uses the <a href="http://v4-alpha.getbootstrap.com/layout/grid/">Bootstrap 4 Flex Grid</a>. This is a 12-column, responsive grid, per the Bootstrap documentation shown below:</p>
 
-  <p>Clarity uses the <a href="http://v4-alpha.getbootstrap.com/layout/grid/">Bootstrap 4 Flex Grid</a>.  This is a 12-column, responsive grid, per the Bootstrap documentation shown below:</p>
+    <div class="row">
+        <div class="col-xs-12">
+            <table class="table hidden-xs-down">
+                <thead>
+                    <tr>
+                        <th class="left"></th>
+                        <th class="left">Extra Small</th>
+                        <th class="left">Small</th>
+                        <th class="left">Medium</th>
+                        <th class="left">Large</th>
+                        <th class="left">Extra Large</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="left">Grid behavior</td>
+                        <td class="left">Horizontal</td>
+                        <td class="left" colspan="4">Collapsed to start, horizontal above breakpoints</td>
+                    </tr>
+                    <tr>
+                        <td class="left">Container width</td>
+                        <td class="left">&lt;544px</td>
+                        <td class="left">≥544px</td>
+                        <td class="left">≥768px</td>
+                        <td class="left">≥992px</td>
+                        <td class="left">≥1200px</td>
+                    </tr>
+                    <tr>
+                        <td class="left">Class prefix</td>
+                        <td class="left"><code class="clr-code">.col-xs-</code></td>
+                        <td class="left"><code class="clr-code">.col-sm-</code></td>
+                        <td class="left"><code class="clr-code">.col-md-</code></td>
+                        <td class="left"><code class="clr-code">.col-lg-</code></td>
+                        <td class="left"><code class="clr-code">.col-xl-</code></td>
+                    </tr>
+                    <tr>
+                        <td class="left">Number of columns</td>
+                        <td class="left" colspan="5">12</td>
+                    </tr>
+                    <tr>
+                        <td class="left">Gutter width</td>
+                        <td class="left" colspan="5">24px (12px on the left and right of column)</td>
+                    </tr>
+                    <tr>
+                        <td class="left">Nestable</td>
+                        <td class="left" colspan="5">Yes</td>
+                    </tr>
+                    <tr>
+                        <td class="left">Offsets</td>
+                        <td class="left" colspan="5">Yes</td>
+                    </tr>
+                    <tr>
+                        <td class="left">Column order</td>
+                        <td class="left" colspan="5">Yes</td>
+                    </tr>
+                </tbody>
+            </table>
 
-  <div class="row">
-    <div class="col-xs-12">
-      <table class="table hidden-xs-down">
-        <thead>
-        <tr>
-          <th class="left"></th>
-          <th class="left">Extra Small</th>
-          <th class="left">Small</th>
-          <th class="left">Medium</th>
-          <th class="left">Large</th>
-          <th class="left">Extra Large</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr>
-          <td class="left">Grid behavior</td>
-          <td class="left">Horizontal</td>
-          <td class="left" colspan="4">Collapsed to start, horizontal above breakpoints</td>
-        </tr>
-        <tr>
-          <td class="left">Container width</td>
-          <td class="left">&lt;544px</td>
-          <td class="left">≥544px</td>
-          <td class="left">≥768px</td>
-          <td class="left">≥992px</td>
-          <td class="left">≥1200px</td>
-        </tr>
-        <tr>
-          <td class="left">Class prefix</td>
-          <td class="left"><code class="clr-code">.col-xs-</code></td>
-          <td class="left"><code class="clr-code">.col-sm-</code></td>
-          <td class="left"><code class="clr-code">.col-md-</code></td>
-          <td class="left"><code class="clr-code">.col-lg-</code></td>
-          <td class="left"><code class="clr-code">.col-xl-</code></td>
-        </tr>
-        <tr>
-          <td class="left">Number of columns</td>
-          <td class="left" colspan="5">12</td>
-        </tr>
-        <tr>
-          <td class="left">Gutter width</td>
-          <td class="left" colspan="5">24px (12px on the left and right of column)</td>
-        </tr>
-        <tr>
-          <td class="left">Nestable</td>
-          <td class="left" colspan="5">Yes</td>
-        </tr>
-        <tr>
-          <td class="left">Offsets</td>
-          <td class="left" colspan="5">Yes</td>
-        </tr>
-        <tr>
-          <td class="left">Column order</td>
-          <td class="left" colspan="5">Yes</td>
-        </tr>
-        </tbody>
-      </table>
+            <div class="hidden-sm-up">
+                <p>
+                    <b>Grid Behavior</b><br /> Horizontal for extra-small (xs). All other breakpoints are collapsed to start, then horizontal above the breakpoint.
+                </p>
 
-      <div class="hidden-sm-up">
-        <p>
-          <b>Grid Behavior</b><br />
-          Horizontal for extra-small (xs). All other breakpoints are
-          collapsed to start, then horizontal above the breakpoint.
-        </p>
+                <p>
+                    <b>Common Properties</b>
+                </p>
 
-        <p>
-          <b>Common Properties</b>
-        </p>
+                <ul class="list">
+                    <li>Number of columns: 12</li>
+                    <li>Gutter width: 24px (12px on the left and right of column)</li>
+                    <li>All columns support nesting, offsets, and column order</li>
+                </ul>
 
-        <ul class="list">
-          <li>Number of columns: 12</li>
-          <li>Gutter width: 24px (12px on the left and right of column)</li>
-          <li>All columns support nesting, offsets, and column order</li>
-        </ul>
+                <table class="table-vertical table">
+                    <tr>
+                        <th>
+                            Extra small<br /> &lt; 544px
+                        </th>
+                        <td>
+                            <code class="clr-code">.col-xs-</code>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>
+                            Small<br /> &ge; 544px
+                        </th>
+                        <td>
+                            <code class="clr-code">.col-sm-</code>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>
+                            Medium<br /> &ge; 768px
+                        </th>
+                        <td>
+                            <code class="clr-code">.col-md-</code>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>
+                            Large<br /> &ge; 992px
+                        </th>
+                        <td>
+                            <code class="clr-code">.col-lg-</code>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>
+                            Extra large<br /> &ge; 1200px
+                        </th>
+                        <td>
+                            <code class="clr-code">.col-xl-</code>
+                        </td>
+                    </tr>
+                </table>
+            </div>
 
-        <table class="table-vertical table">
-          <tr>
-            <th>
-              Extra small<br />
-              &lt; 544px
-            </th>
-            <td>
-              <code class="clr-code">.col-xs-</code>
-            </td>
-          </tr>
-          <tr>
-            <th>
-              Small<br />
-              &ge; 544px
-            </th>
-            <td>
-              <code class="clr-code">.col-sm-</code>
-            </td>
-          </tr>
-          <tr>
-            <th>
-              Medium<br />
-              &ge; 768px
-            </th>
-            <td>
-              <code class="clr-code">.col-md-</code>
-            </td>
-          </tr>
-          <tr>
-            <th>
-              Large<br />
-              &ge; 992px
-            </th>
-            <td>
-              <code class="clr-code">.col-lg-</code>
-            </td>
-          </tr>
-          <tr>
-            <th>
-              Extra large<br />
-              &ge; 1200px
-            </th>
-            <td>
-              <code class="clr-code">.col-xl-</code>
-            </td>
-          </tr>
-        </table>
-      </div>
-
+        </div>
     </div>
-  </div>
 
-  <h3 id="rows">Rows</h3>
+    <h3 id="rows">Rows</h3>
 
-  <p>A <code class="clr-code">.row</code> is a horizontal group of 12 columns. When the number of columns exceeds 12, the extra columns wrap to the next line.</p>
+    <p>A <code class="clr-code">.row</code> is a horizontal group of 12 columns. When the number of columns exceeds 12, the extra columns wrap to the next line.</p>
 
-  <h3 id="columns">Columns</h3>
+    <h3 id="columns">Columns</h3>
 
-  <p>The column classes specify the number of columns per row.  The value appended to the class prefix must be between 1 and 12.</p>
+    <p>The column classes specify the number of columns per row.  The value appended to the class prefix must be between 1 and 12.</p>
 
-  <clr-grid-demo-columns></clr-grid-demo-columns>
+    <clr-grid-demo-columns></clr-grid-demo-columns>
 
-  <h3 id="column-stacking">Column Stacking</h3>
+    <h3 id="column-stacking">Column Stacking</h3>
 
-  <p>Grid columns can occupy different widths on different device sizes.</p>
+    <p>Grid columns can occupy different widths on different device sizes.</p>
 
-  <p>In the example below, if the device size is ≥ 768px (medium or above), the grid has two columns of equal width and a third column that occupies the entire width of the row.  For device sizes &lt; 768px, each column occupies the entire width of the row and the columns are stacked. Resize your browser to see how this works.</p>
+    <p>In the example below, if the device size is ≥ 768px (medium or above), the grid has two columns of equal width and a third column that occupies the entire width of the row.  For device sizes &lt; 768px, each column occupies the entire width of the
+        row and the columns are stacked. Resize your browser to see how this works.</p>
 
-  <clr-grid-demo-column-stacking></clr-grid-demo-column-stacking>
+    <clr-grid-demo-column-stacking></clr-grid-demo-column-stacking>
 
-  <h3 id="column-offsets">Column Offsets</h3>
+    <h3 id="column-offsets">Column Offsets</h3>
 
-  <p>The <code class="clr-code">&lt;class-prefix&gt;-offset-*</code> classes increase a column’s left margin by the width occupied by <code>*</code> number of columns.</p>
-  <clr-grid-demo-column-offsetting></clr-grid-demo-column-offsetting>
+    <p>The <code class="clr-code">&lt;class-prefix&gt;-offset-*</code> classes increase a column’s left margin by the width occupied by <code>*</code> number of columns.</p>
+    <clr-grid-demo-column-offsetting></clr-grid-demo-column-offsetting>
 
-  <h3 id="column-ordering">Column Ordering</h3>
+    <h3 id="column-ordering">Column Ordering</h3>
 
-  <p>The <code class="clr-code">push</code> and <code class="clr-code">pull</code> modifiers change the order of columns.</p>
+    <p>The <code class="clr-code">push</code> and <code class="clr-code">pull</code> modifiers change the order of columns.</p>
 
-  <h4 id="push">Push</h4>
+    <h4 id="push">Push</h4>
 
-  <clr-grid-demo-column-push></clr-grid-demo-column-push>
+    <clr-grid-demo-column-push></clr-grid-demo-column-push>
 
-  <h4 id="pull">Pull</h4>
+    <h4 id="pull">Pull</h4>
 
-  <clr-grid-demo-column-pull></clr-grid-demo-column-pull>
+    <clr-grid-demo-column-pull></clr-grid-demo-column-pull>
 
-  <h3 id="flexbox-grid-auto-layout">Flexbox Grid Auto Layout</h3>
+    <h3 id="flexbox-grid-auto-layout">Flexbox Grid Auto Layout</h3>
 
-  <p>Using the <code class="clr-code">.col-&lt;breakpoint&gt;</code> class divides the row into equal width columns.</p>
+    <p>Using the <code class="clr-code">.col-&lt;breakpoint&gt;</code> class divides the row into equal width columns.</p>
 
-  <clr-grid-demo-auto-layout-1></clr-grid-demo-auto-layout-1>
+    <clr-grid-demo-auto-layout-1></clr-grid-demo-auto-layout-1>
 
-  <clr-grid-demo-auto-layout-2></clr-grid-demo-auto-layout-2>
+    <clr-grid-demo-auto-layout-2></clr-grid-demo-auto-layout-2>
 
-  <h3 id="vertical-alignment-in-rows">Vertical Alignment in Rows</h3>
+    <h3 id="vertical-alignment-in-rows">Vertical Alignment in Rows</h3>
 
-  <p>Columns within a row can be vertically aligned using the following classes:</p>
+    <p>Columns within a row can be vertically aligned using the following classes:</p>
 
-  <ul>
-    <li><code class="clr-code">flex-items-xs-top</code></li>
-    <li><code class="clr-code">flex-items-xs-middle</code></li>
-    <li><code class="clr-code">flex-items-xs-bottom</code></li>
-  </ul>
+    <ul>
+        <li><code class="clr-code">flex-items-xs-top</code></li>
+        <li><code class="clr-code">flex-items-xs-middle</code></li>
+        <li><code class="clr-code">flex-items-xs-bottom</code></li>
+    </ul>
 
-  <clr-grid-demo-vertical-alignment></clr-grid-demo-vertical-alignment>
+    <clr-grid-demo-vertical-alignment></clr-grid-demo-vertical-alignment>
 
-  <p>A column can individually be vertically aligned in a row using the following classes:</p>
+    <p>A column can individually be vertically aligned in a row using the following classes:</p>
 
-  <ul>
-    <li><code class="clr-code">flex-xs-top</code></li>
-    <li><code class="clr-code">flex-xs-middle</code></li>
-    <li><code class="clr-code">flex-xs-bottom</code></li>
-  </ul>
+    <ul>
+        <li><code class="clr-code">flex-xs-top</code></li>
+        <li><code class="clr-code">flex-xs-middle</code></li>
+        <li><code class="clr-code">flex-xs-bottom</code></li>
+    </ul>
 
-  <clr-grid-demo-individual-vertical-alignment></clr-grid-demo-individual-vertical-alignment>
+    <clr-grid-demo-individual-vertical-alignment></clr-grid-demo-individual-vertical-alignment>
 
-  <h3 id="horizontal-alignment-in-rows">Horizontal Alignment in Rows</h3>
+    <h3 id="horizontal-alignment-in-rows">Horizontal Alignment in Rows</h3>
 
-  <p>To align columns horizontally within a row, extend the row with one of the following classes:</p>
+    <p>To align columns horizontally within a row, extend the row with one of the following classes:</p>
 
-  <ul>
-    <li><code class="clr-code">flex-items-xs-left</code></li>
-    <li><code class="clr-code">flex-items-xs-center</code></li>
-    <li><code class="clr-code">flex-items-xs-right</code></li>
-    <li><code class="clr-code">flex-items-xs-around</code></li>
-    <li><code class="clr-code">flex-items-xs-between</code></li>
-  </ul>
+    <ul>
+        <li><code class="clr-code">flex-items-xs-left</code></li>
+        <li><code class="clr-code">flex-items-xs-center</code></li>
+        <li><code class="clr-code">flex-items-xs-right</code></li>
+        <li><code class="clr-code">flex-items-xs-around</code></li>
+        <li><code class="clr-code">flex-items-xs-between</code></li>
+    </ul>
 
-  <clr-grid-demo-horizontal-alignment></clr-grid-demo-horizontal-alignment>
+    <clr-grid-demo-horizontal-alignment></clr-grid-demo-horizontal-alignment>
 
-  <h3 id="guidelines">Usage</h3>
+    <h3 id="guidelines">Usage</h3>
 
-  <p>Clarity recommends that your application layout stay on the grid.  A grid-based approach:</p>
+    <p>Clarity recommends that your application layout stay on the grid. A grid-based approach:</p>
 
-  <ul class="list">
-    <li>Aligns content consistently</li>
-    <li>Establishes a foundation that can be easily built upon for future designs</li>
-    <li>Simplifies layout decisions required of a designer</li>
-    <li>Coordinates the efforts of multiple designers</li>
-  </ul>
+    <ul class="list">
+        <li>Aligns content consistently</li>
+        <li>Establishes a foundation that can be easily built upon for future designs</li>
+        <li>Simplifies layout decisions required of a designer</li>
+        <li>Coordinates the efforts of multiple designers</li>
+    </ul>
 
-  <h4 id="applying-the-grid">Applying the Grid</h4>
+    <h4 id="applying-the-grid">Applying the Grid</h4>
 
-  <p>Apply the grid with consideration of content. Some pages might benefit from a three-column layout, where other pages might work best with a two-column layout.</p>
+    <p>Apply the grid with consideration of content. Some pages might benefit from a three-column layout, where other pages might work best with a two-column layout.</p>
 
-  <p>You can vary the column layout within the same page.  This strategy works well for presenting content that scrolls vertically.</p>
+    <p>You can vary the column layout within the same page. This strategy works well for presenting content that scrolls vertically.</p>
 
-  <p>Don’t lock your design into a layout optimized for a large window.</p>
+    <p>Don’t lock your design into a layout optimized for a large window.</p>
 
-  <h4 id="grids-and-card-layouts">Grids and Card Layouts</h4>
+    <h4 id="grids-and-card-layouts">Grids and Card Layouts</h4>
 
-  <p>Designing to a grid is especially important for <a href="/clarity/documentation/cards">card</a> layouts.  Cards contains blocks of content and their height and width can vary.  The grid aligns the cards in a way that is easy for users to navigate.</p>
+    <p>Designing to a grid is especially important for <a routerLink="/documentation/cards">card</a> layouts. Cards contains blocks of content and their height and width can vary. The grid aligns the cards in a way that is easy for users to navigate.</p>
 
-  <h4 id="if-you-decide-not-to-conform-to-the-grid">If You Decide Not to Conform to the Grid</h4>
+    <h4 id="if-you-decide-not-to-conform-to-the-grid">If You Decide Not to Conform to the Grid</h4>
 
-  <p>Do so with intent. Find a balance between aesthetics and conformity. Keep in mind that elements that are not aligned to the grid draw attention in the same way as color, contrast, and iconography and require more cognitive effort on the part of the user.</p>
+    <p>Do so with intent. Find a balance between aesthetics and conformity. Keep in mind that elements that are not aligned to the grid draw attention in the same way as color, contrast, and iconography and require more cognitive effort on the part of the
+        user.</p>
 </article>

--- a/src/pages/documentation/header.html
+++ b/src/pages/documentation/header.html
@@ -1,108 +1,109 @@
+<article>
+    <h5 class="component-summary" id="the-header-and-subnav-support-app-level-information-and-navigation-links">The header and subnav support app-level information and navigation links.</h5>
 
-<article><h5 class="component-summary" id="the-header-and-subnav-support-app-level-information-and-navigation-links">The header and subnav support app-level information and navigation links.</h5>
+    <h3 id="header">Header</h3>
 
-  <h3 id="header">Header</h3>
+    <h6 id="header-1">.header</h6>
 
-  <h6 id="header-1">.header</h6>
+    <p><code class="clr-code">.header</code> is a wrapper around the following four sections:</p>
 
-  <p><code class="clr-code">.header</code> is a wrapper around the following four sections:</p>
+    <ul class="list">
+        <li>Branding</li>
+        <li>Navigation</li>
+        <li>Search</li>
+        <li>Settings</li>
+    </ul>
 
-  <ul class="list">
-    <li>Branding</li>
-    <li>Navigation</li>
-    <li>Search</li>
-    <li>Settings</li>
-  </ul>
+    <h6 id="branding">.branding</h6>
 
-  <h6 id="branding">.branding</h6>
+    <p><code class="clr-code">.branding</code> contains the product logo and the product title. The logo extends the <code class="clr-code">.clr-icon</code> class and the title extends the <code class="clr-code">.title</code> class.</p>
 
-  <p><code class="clr-code">.branding</code> contains the product logo and the product title. The logo extends the <code class="clr-code">.clr-icon</code> class and the title extends the <code class="clr-code">.title</code> class.</p>
+    <h6 id="header-nav">.header-nav</h6>
 
-  <h6 id="header-nav">.header-nav</h6>
+    <p><code class="clr-code">.header-nav</code> contains the navigation links. Each navigation link extends the <code class="clr-code">.nav-link</code> class. Navigation links can be text or icons.</p>
 
-  <p><code class="clr-code">.header-nav</code> contains the navigation links. Each navigation link extends the <code class="clr-code">.nav-link</code> class. Navigation links can be text or icons.</p>
+    <h6 id="search">.search</h6>
 
-  <h6 id="search">.search</h6>
+    <p><code class="clr-code">.search</code> is a form containing the search icon and the search input field.</p>
 
-  <p><code class="clr-code">.search</code> is a form containing the search icon and the search input field.</p>
+    <h6 id="header-actions">.header-actions</h6>
 
-  <h6 id="header-actions">.header-actions</h6>
+    <p><code class="clr-code">.header-actions</code> is a wrapper that contains secondary navigation links. Each navigation link extends the <code class="clr-code">.nav-link</code> class. Navigation links can be text or icons.</p>
 
-  <p><code class="clr-code">.header-actions</code> is a wrapper that contains secondary navigation links. Each navigation link extends the <code class="clr-code">.nav-link</code> class. Navigation links can be text or icons.</p>
+    <h4 id="types">Types</h4>
+    <clr-header-demo-types></clr-header-demo-types>
 
-  <h4 id="types">Types</h4>
-  <clr-header-demo-types></clr-header-demo-types>
+    <p>For information about responsive headers, see <a routerLink="/documentation/navigation#responsive_navigation">Responsive Navigation</a>.</p>
 
-  <p>For information about responsive headers, see <a href="/clarity/documentation/navigation#responsive_navigation">Responsive Navigation</a>.</p>
+    <h4 id="color-options">Color Options</h4>
+    <clr-header-demo-colors></clr-header-demo-colors>
 
-  <h4 id="color-options">Color Options</h4>
-  <clr-header-demo-colors></clr-header-demo-colors>
+    <h3 id="subnav">Subnav</h3>
 
-  <h3 id="subnav">Subnav</h3>
+    <p><code class="clr-code">.sub-nav</code> immediately follows the <code class="clr-code">.header</code>. It wraps a <a routerLink="/documentation/tabs">tab</a> and an <code class="clr-code">aside</code> section.</p>
 
-  <p><code class="clr-code">.sub-nav</code> immediately follows the <code class="clr-code">.header</code>. It wraps a <a href="/clarity/documentation/tabs">tab</a> and an <code class="clr-code">aside</code> section.</p>
+    <clr-nav-demo-subnav></clr-nav-demo-subnav>
 
-  <clr-nav-demo-subnav></clr-nav-demo-subnav>
+    <h3 id="guidelines">Using Headers</h3>
 
-  <h3 id="guidelines">Using Headers</h3>
+    <p>The Clarity header can include the following elements, placed from left to right:</p>
 
-  <p>The Clarity header can include the following elements, placed from left to right:</p>
+    <ul class="list">
+        <li>Product identification</li>
+        <li>Navigation</li>
+        <li>Search</li>
+        <li>Settings</li>
+    </ul>
 
-  <ul class="list">
-    <li>Product identification</li>
-    <li>Navigation</li>
-    <li>Search</li>
-    <li>Settings</li>
-  </ul>
+    <!--![Navigation](/clarity/images/documentation/header/Navigation_header.png)-->
 
-  <!--![Navigation](/clarity/images/documentation/header/Navigation_header.png)-->
+    <h4 id="product-identification">Product Identification</h4>
+    <p>A minimum of 200 pixels is recommended to avoid crowding the left side of the header. Clicking on the product name should return the user to the home page.</p>
 
-  <h4 id="product-identification">Product Identification</h4>
-  <p>A minimum of 200 pixels is recommended to avoid crowding the left side of the header.  Clicking on the product name should return the user to the home page.</p>
+    <h4 id="navigation">Navigation</h4>
 
-  <h4 id="navigation">Navigation</h4>
+    <p>The header works best for two to four links. For less than two, navigation is not needed. For more than four, use the subnav or <a routerLink="/documentation/sidenav">sidenav</a>. Although users commonly look for app-level navigation in the header,
+        having too many main links can cause navigation to lose its meaning.</p>
 
-  <p>The header works best for two to four links. For less than two, navigation is not needed. For more than four, use the subnav or <a href="/clarity/documentation/sidenav">sidenav</a>.  Although users commonly look for app-level navigation in the header, having too many main links can cause navigation to lose its meaning.</p>
+    <h4 id="text-links">Text Links</h4>
 
-  <h4 id="text-links">Text Links</h4>
+    <p>The preferred format of navigation links is text because it is generally better understood than icons. Use one to two words per link, with a limit of 16 characters. Do not wrap text.</p>
 
-  <p>The preferred format of navigation links is text because it is generally better understood than icons.  Use one to two words per link, with a limit of 16 characters.  Do not wrap text.</p>
+    <h4 id="icon-links">Icon Links</h4>
 
-  <h4 id="icon-links">Icon Links</h4>
+    <p>Ensure that the icons are clearly recognizable, for example, Search. Alternately, include a text label, for example, a cloud icon and the text “Cloud Infrastructure.” You can also provide a tooltip that describes the function of the icon.</p>
 
-  <p>Ensure that the icons are clearly recognizable, for example, Search. Alternately, include a text label, for example, a cloud icon and the text “Cloud Infrastructure.”  You can also provide a tooltip that describes the function of the icon.</p>
+    <p>Don’t mix standalone icons with standalone text links.</p>
 
-  <p>Don’t mix standalone icons with standalone text links.</p>
+    <h4 id="search-1">Search</h4>
 
-  <h4 id="search-1">Search</h4>
+    <p>Consider placement of Search as follows:</p>
 
-  <p>Consider placement of Search as follows:</p>
+    <ul class="list">
+        <li>If the header includes navigation links, place Search to the immediate right of the links.</li>
+        <li>If the header does not include navigation, make Search the central point.</li>
+        <li>Otherwise, align Search on the right.</li>
+    </ul>
 
-  <ul class="list">
-    <li>If the header includes navigation links, place Search to the immediate right of the links.</li>
-    <li>If the header does not include navigation, make Search the central point.</li>
-    <li>Otherwise, align Search on the right.</li>
-  </ul>
+    <p>For larger screens, include placeholder text in the Search field to give users an example of a search query.</p>
 
-  <p>For larger screens, include placeholder text in the Search field to give users an example of a search query.</p>
+    <!--![Search](/clarity/images/documentation/header/Search_header.png)-->
 
-  <!--![Search](/clarity/images/documentation/header/Search_header.png)-->
+    <h4 id="settings">Settings</h4>
 
-  <h4 id="settings">Settings</h4>
+    <p>Settings are typically right-aligned. These might include app-related actions such as help and logout. Don’t overcrowd the header with too many settings–consolidate them in a dropdown menu.</p>
 
-  <p>Settings are typically right-aligned.  These might include app-related actions such as help and logout.  Don’t overcrowd the header with too many settings–consolidate them in a dropdown menu.</p>
+    <h4 id="colors">Colors</h4>
 
-  <h4 id="colors">Colors</h4>
+    <p>Headers have their own color palette. These colors make the header visually recede in focus so it does not compete with the content area.</p>
 
-  <p>Headers have their own color palette.  These colors make the header visually recede in focus so it does not compete with the content area.</p>
+    <p><img src="/assets/images/documentation/header/Colors.png" alt="Header Colors" /></p>
 
-  <p><img src="/assets/images/documentation/header/Colors.png" alt="Header Colors" /></p>
+    <h3 id="using-the-subnav">Using the Subnav</h3>
+    <p>The subnav is recommended for either app-level navigation links or for links secondary to the ones in the header. For best use of the horizontal space, include five to seven links. Less than five might leave too much empty space.</p>
 
-  <h3 id="using-the-subnav">Using the Subnav</h3>
-  <p>The subnav is recommended for either app-level navigation links or for links secondary to the ones in the header. For best use of the horizontal space, include five to seven links.  Less than five might leave too much empty space.</p>
+    <p>Use text for the link names, not icons. Ensure that the text is clear and concise.</p>
 
-  <p>Use text for the link names, not icons. Ensure that the text is clear and concise.</p>
-
-  <!--
+    <!--
   ![Subnav](/clarity/images/documentation/header/Subnav_header.png)-->
 </article>

--- a/src/pages/documentation/input-fields.html
+++ b/src/pages/documentation/input-fields.html
@@ -1,91 +1,86 @@
+<article>
+    <h5 class="component-summary" id="clarity-has-a-single-line-input-field-and-a-multiline-text-area">Clarity has a single-line input field and a multiline text area.</h5>
 
-<article><h5 class="component-summary" id="clarity-has-a-single-line-input-field-and-a-multiline-text-area">Clarity has a single-line input field and a multiline text area.</h5>
+    <p>Input fields are composed of a label followed by an <code class="clr-code">input</code> or <code class="clr-code">textarea</code> wrapped in a block element with the <code class="clr-code">.form-group</code> classname applied to it.</p>
 
-  <p>Input fields are composed of a label followed by an <code class="clr-code">input</code> or <code class="clr-code">textarea</code> wrapped in a block element with the <code class="clr-code">.form-group</code> classname applied to it.</p>
+    <clr-input-fields-demo></clr-input-fields-demo>
 
-  <clr-input-fields-demo></clr-input-fields-demo>
+    <h4 id="form-validation">Form Validation</h4>
 
-  <h4 id="form-validation">Form Validation</h4>
+    <p>You can use validation styling for input fields by wrapping the input tag in a container with the <code class="clr-code">.tooltip</code> class along with the <code class="clr-code">.tooltip-validation</code> class. Use the <code class="clr-code">.invalid</code>        class on the <code class="clr-code">.tooltip-validation</code> container to toggle the validation styling. Place the <code class="clr-code">.tooltip-content</code> <b>after</b> the <code class="clr-code">input</code> tag.</p>
 
-  <p>You can use validation styling for input fields by wrapping the input tag in a
-    container with the <code class="clr-code">.tooltip</code> class along with the <code class="clr-code">.tooltip-validation</code> class.
-    Use the <code class="clr-code">.invalid</code> class on the <code class="clr-code">.tooltip-validation</code> container to toggle
-    the validation styling. Place the <code class="clr-code">.tooltip-content</code> <b>after</b>
-    the <code class="clr-code">input</code> tag.</p>
+    <p>You can set the direction of the tooltip using these classes:</p>
 
-  <p>You can set the direction of the tooltip using these classes:</p>
+    <ul>
+        <li>.top-right (default)</li>
+        <li>.top-left</li>
+        <li>.bottom-right</li>
+        <li>.bottom-left</li>
+    </ul>
 
-  <ul>
-    <li>.top-right (default)</li>
-    <li>.top-left</li>
-    <li>.bottom-right</li>
-    <li>.bottom-left</li>
-  </ul>
+    <p>You can set the size of the tooltips using these classes:</p>
 
-  <p>You can set the size of the tooltips using these classes:</p>
+    <ul>
+        <li>.tooltip-xs</li>
+        <li>.tooltip-sm</li>
+        <li>.tooltip-md</li>
+        <li>.tooltip-lg</li>
+    </ul>
 
-  <ul>
-    <li>.tooltip-xs</li>
-    <li>.tooltip-sm</li>
-    <li>.tooltip-md</li>
-    <li>.tooltip-lg</li>
-  </ul>
+    <h4 id="example">Example</h4>
 
-  <h4 id="example">Example</h4>
+    <clr-forms-demo-validation></clr-forms-demo-validation>
 
-  <clr-forms-demo-validation></clr-forms-demo-validation>
+    <h3 id="guidelines">Usage</h3>
 
-  <h3 id="guidelines">Usage</h3>
+    <h4 id="labels">Labels</h4>
 
-  <h4 id="labels">Labels</h4>
+    <p>Input fields require a brief label to indicate what information belongs in the field. The label appears to the left of the input field and moves above it when the app is resized smaller.</p>
 
-  <p>Input fields require a brief label to indicate what information belongs in the field.  The label appears to the left of the input field and moves above it when the app is resized smaller.</p>
+    <ul class="list">
+        <li>Ensure that the label wording is clear.</li>
+        <li>Keep the text to a single line.</li>
+        <li>Use sentence caps without final punctuation.</li>
+    </ul>
 
-  <ul class="list">
-    <li>Ensure that the label wording is clear.</li>
-    <li>Keep the text to a single line.</li>
-    <li>Use sentence caps without final punctuation.</li>
-  </ul>
+    <h4 id="placeholder-text">Placeholder Text</h4>
 
-  <h4 id="placeholder-text">Placeholder Text</h4>
+    <p>Located inside a field, placeholder text can help clarify expected input. Placeholder text disappears when the user types in the field.</p>
 
-  <p>Located inside a field, placeholder text can help clarify expected input.  Placeholder text disappears when the user types in the field.</p>
+    <p>Tip: Use the label to show what information goes in the field and placeholder text as a hint, description, or example format:</p>
 
-  <p>Tip: Use the label to show what information goes in the field and placeholder text as a hint, description, or example format:</p>
+    <p>Label: Airport
+        <br /> Placeholder text: SFO, SJO</p>
 
-  <p>Label: Airport
-    <br />
-    Placeholder text:  SFO, SJO</p>
+    <p>Placeholder text can replace labels only in simple forms with a few easily-understood fields, see the <a routerLink="/documentation/login">login page</a>.</p>
 
-  <p>Placeholder text can replace labels only in simple forms with a few easily-understood fields, see the <a href="/clarity/documentation/login">login page</a>.</p>
+    <p>Placeholder text is not required for every input field.</p>
 
-  <p>Placeholder text is not required for every input field.</p>
+    <h4 id="size">Size</h4>
 
-  <h4 id="size">Size</h4>
+    <p>For the best user experience, consider localization and keep in mind that word length varies among languages.</p>
 
-  <p>For the best user experience, consider localization and keep in mind that word length varies among languages.</p>
+    <h4 id="multiple-input-fields">Multiple Input Fields</h4>
 
-  <h4 id="multiple-input-fields">Multiple Input Fields</h4>
+    <p>A complex form might have multiple input fields, stacked vertically. Space the input fields evenly, clearly associating labels with the corresponding input fields.</p>
 
-  <p>A complex form might have multiple input fields, stacked vertically.  Space the input fields evenly, clearly associating labels with the corresponding input fields.</p>
+    <h4 id="validation">Validation</h4>
 
-  <h4 id="validation">Validation</h4>
+    <p>Avoid overlaying the validation tooltip on the data is being validated. By default, the position of the tooltip is to the top-right of the error icon, pointing to its center. Other positions to consider are:</p>
 
-  <p>Avoid overlaying the validation tooltip on the data is being validated. By default, the position of the tooltip is to the top-right of the error icon, pointing to its center. Other positions to consider are:</p>
+    <ul class="list">
+        <li>Top left</li>
+        <li>Bottom right</li>
+        <li>Bottom left</li>
+        <li>Side left</li>
+        <li>Side right</li>
+    </ul>
 
-  <ul class="list">
-    <li>Top left</li>
-    <li>Bottom right</li>
-    <li>Bottom left</li>
-    <li>Side left</li>
-    <li>Side right</li>
-  </ul>
+    <p>Base the width of the tooltip on the message text. Choices are 72 px, 120 px, 240 px, and 360 px. The default is 240 px.</p>
 
-  <p>Base the width of the tooltip on the message text.  Choices are 72 px, 120 px, 240 px, and 360 px.  The default is 240 px.</p>
+    <p>Make the message text short, but informative. For example, “The username already exists. Enter a new name.” Try to limit the text to one line.</p>
 
-  <p>Make the message text short, but informative.  For example, “The username already exists.  Enter a new name.”  Try to limit the text to one line.</p>
+    <h4 id="multiline-text-area">Multiline Text Area</h4>
 
-  <h4 id="multiline-text-area">Multiline Text Area</h4>
-
-  <p>Use a multiline text area when a user must enter a long string.  Content wraps when the cursor reaches the right edge and scrolls when it reaches the lower edge.</p>
+    <p>Use a multiline text area when a user must enter a long string. Content wraps when the cursor reaches the right edge and scrolls when it reaches the lower edge.</p>
 </article>

--- a/src/pages/documentation/labels.html
+++ b/src/pages/documentation/labels.html
@@ -1,45 +1,46 @@
+<article>
+    <h5 class="component-summary" id="a-label-is-a-visual-tag-that-provides-additional-information-about-data-in-the-ui">A label is a visual tag that provides additional information about data in the UI.</h5>
 
-<article><h5 class="component-summary" id="a-label-is-a-visual-tag-that-provides-additional-information-about-data-in-the-ui">A label is a visual tag that provides additional information about data in the UI.</h5>
+    <h6 id="labels-not-clickable">1. Labels (not clickable)</h6>
 
-  <h6 id="labels-not-clickable">1. Labels (not clickable)</h6>
+    <clr-labels-default-demo></clr-labels-default-demo>
 
-  <clr-labels-default-demo></clr-labels-default-demo>
+    <h6 id="color-options">2. Color Options</h6>
 
-  <h6 id="color-options">2. Color Options</h6>
+    <clr-labels-color-options-demo></clr-labels-color-options-demo>
 
-  <clr-labels-color-options-demo></clr-labels-color-options-demo>
+    <h6 id="clickable-labels">3. Clickable Labels</h6>
 
-  <h6 id="clickable-labels">3. Clickable Labels</h6>
+    <clr-labels-clickable-demo></clr-labels-clickable-demo>
 
-  <clr-labels-clickable-demo></clr-labels-clickable-demo>
+    <h6 id="status-labels-not-clickable">4. Status Labels (not clickable)</h6>
 
-  <h6 id="status-labels-not-clickable">4. Status Labels (not clickable)</h6>
+    <clr-labels-status-demo></clr-labels-status-demo>
 
-  <clr-labels-status-demo></clr-labels-status-demo>
+    <h6 id="labels-with-badges">5. Labels with Badges</h6>
 
-  <h6 id="labels-with-badges">5. Labels with Badges</h6>
+    <clr-labels-with-badges-demo></clr-labels-with-badges-demo>
 
-  <clr-labels-with-badges-demo></clr-labels-with-badges-demo>
+    <h3 id="guidelines">Usage</h3>
 
-  <h3 id="guidelines">Usage</h3>
+    <p>Use labels in lists and search results to further qualify the data. For example, in search results, you might use labels to filter for location (“London” and “Palo Alto”).</p>
 
-  <p>Use labels in lists and search results to further qualify the data.   For example, in search results, you might use labels to filter for location (“London” and “Palo Alto”).</p>
+    <p>Labels also communicate “Warning,” “Error,” “Success,” and “Info” use cases. These labels are similar to banners and are not clickable.</p>
 
-  <p>Labels also communicate “Warning,” “Error,” “Success,” and “Info” use cases.  These labels are similar to banners and are not clickable.</p>
+    <h4 id="color-palettes">Color Palettes</h4>
 
-  <h4 id="color-palettes">Color Palettes</h4>
+    <p>Labels have two color palettes. For most labels, choose from the standard five-color palette. For labels that communicate status (info, success, warning, and error) use the blue, green, yellow and red palette. Both color palettes were designed to
+        easily differentiate labels from buttons.</p>
 
-  <p>Labels have two color palettes.  For most labels, choose from the standard five-color palette.  For labels that communicate status (info, success, warning, and error) use the blue, green, yellow and red palette.  Both color palettes were designed to easily differentiate labels from buttons.</p>
+    <h4 id="clickable-labels-1">Clickable Labels</h4>
 
-  <h4 id="clickable-labels-1">Clickable Labels</h4>
+    <p>Use a clickable label to navigate to a page that provides more information than is conveyed in the label text.</p>
 
-  <p>Use a clickable label to navigate to a page that provides more information than is conveyed in the label text.</p>
+    <h4 id="overlaying-badges">Overlaying Badges</h4>
 
-  <h4 id="overlaying-badges">Overlaying Badges</h4>
+    <p>You can overlay a <a routerLink="/documentation/badges">badge</a> on a label to provide a count or tally of the items in the label classification.</p>
 
-  <p>You can overlay a <a href="/clarity/documentation/badges">badge</a> on a label to provide a count or tally of the items in the label classification.</p>
+    <h4 id="label-text">Label Text</h4>
 
-  <h4 id="label-text">Label Text</h4>
-
-  <p>Keep label text short–never wrap it to the next line.</p>
+    <p>Keep label text short–never wrap it to the next line.</p>
 </article>

--- a/src/pages/documentation/navigation.html
+++ b/src/pages/documentation/navigation.html
@@ -1,114 +1,114 @@
+<article>
+    <h5 class="component-summary" id="a-sound-navigation-layout-offers-a-high-degree-of-discoverability-and-feedback-letting-users-know-where-they-are-at-all-times-and-ensuring-they-can-easily-get-to-where-they-want-to-go">A sound navigation layout offers a high degree of discoverability and feedback, letting users know where they are at all times and ensuring they can easily get to where they want to go.</h5>
 
-<article><h5 class="component-summary" id="a-sound-navigation-layout-offers-a-high-degree-of-discoverability-and-feedback-letting-users-know-where-they-are-at-all-times-and-ensuring-they-can-easily-get-to-where-they-want-to-go">A sound navigation layout offers a high degree of discoverability and feedback, letting users know where they are at all times and ensuring they can easily get to where they want to go.</h5>
+    <p>Clarity has three navigation components: header, subnav, and sidenav. Following are the possible combinations of navigation.</p>
 
-  <p>Clarity has three navigation components: header, subnav, and sidenav.  Following are the possible
-    combinations of navigation.</p>
+    <h6 id="header-as-primary-navigation-and-subnav-as-secondary-navigation">1. Header as primary navigation and subnav as secondary navigation</h6>
+    <clr-layout-no-sidenav-demo></clr-layout-no-sidenav-demo>
 
-  <h6 id="header-as-primary-navigation-and-subnav-as-secondary-navigation">1. Header as primary navigation and subnav as secondary navigation</h6>
-  <clr-layout-no-sidenav-demo></clr-layout-no-sidenav-demo>
+    <h6 id="header-as-primary-navigation-and-sidenav-as-secondary-navigation">2. Header as primary navigation and sidenav as secondary navigation</h6>
+    <clr-layout-no-subnav-demo></clr-layout-no-subnav-demo>
 
-  <h6 id="header-as-primary-navigation-and-sidenav-as-secondary-navigation">2. Header as primary navigation and sidenav as secondary navigation</h6>
-  <clr-layout-no-subnav-demo></clr-layout-no-subnav-demo>
+    <h6 id="header-as-primary-navigation">3. Header as primary navigation</h6>
+    <clr-layout-only-header-demo></clr-layout-only-header-demo>
 
-  <h6 id="header-as-primary-navigation">3. Header as primary navigation</h6>
-  <clr-layout-only-header-demo></clr-layout-only-header-demo>
+    <h6 id="sidenav-as-primary-navigation">4. Sidenav as primary navigation</h6>
+    <clr-layout-only-sidenav-primary></clr-layout-only-sidenav-primary>
 
-  <h6 id="sidenav-as-primary-navigation">4. Sidenav as primary navigation</h6>
-  <clr-layout-only-sidenav-primary></clr-layout-only-sidenav-primary>
+    <h6 id="subnav-as-primary-navigation-and-sidenav-as-secondary-navigation">5. Subnav as primary navigation and sidenav as secondary navigation</h6>
+    <clr-layout-only-subnav-primary></clr-layout-only-subnav-primary>
 
-  <h6 id="subnav-as-primary-navigation-and-sidenav-as-secondary-navigation">5. Subnav as primary navigation and sidenav as secondary navigation</h6>
-  <clr-layout-only-subnav-primary></clr-layout-only-subnav-primary>
+    <p>
+        <a id="responsive_navigation"></a>
+    </p>
 
-  <p><a id="responsive_navigation"></a></p>
+    <h3 id="responsive-navigation">Responsive Navigation</h3>
 
-  <h3 id="responsive-navigation">Responsive Navigation</h3>
+    <p>Clarity provides three levels of navigation represented by the following classnames:</p>
 
-  <p>Clarity provides three levels of navigation represented by the following classnames:</p>
+    <ul class="list cozy-sm">
+        <li><code class="clr-code">.header-nav</code> in the application <a routerLink="/documentation/header">header</a>.</li>
+        <li><code class="clr-code">.subnav</code> immediately below the header.</li>
+        <li><code class="clr-code">.sidenav</code> inside the content container. See <a routerLink="/documentation/sidenav">sidenav</a>.</li>
+    </ul>
 
-  <ul class="list cozy-sm">
-    <li><code class="clr-code">.header-nav</code> in the application <a href="/clarity/documentation/header">header</a>.</li>
-    <li><code class="clr-code">.subnav</code> immediately below the header.</li>
-    <li><code class="clr-code">.sidenav</code> inside the content container. See <a href="/clarity/documentation/sidenav">sidenav</a>.</li>
-  </ul>
-
-  <p>
-    Clarity supports responsive navigation as follows:
-  </p>
-  <ul class="list cozy-sm">
-    <li>
-      Up to two levels of navigation can be made responsive.
-    </li>
-    <li>
-      Responsiveness is triggered below the <code class="clr-code">768px</code> breakpoint by adding the <code class="clr-code">clr-nav-level</code> input to the navigation level.
-    </li>
-    <li>
-      A <code class="clr-code">clr-nav-level</code> value of <code class="clr-code">1</code> is for primary navigation and <code class="clr-code">2</code> is for secondary navigation.
-    </li>
-    <li>
-      On small screens:
-      <ul class="list cozy-sm">
+    <p>
+        Clarity supports responsive navigation as follows:
+    </p>
+    <ul class="list cozy-sm">
         <li>
-          The hamburger icon appears on the left of the header and triggers the primary navigation
+            Up to two levels of navigation can be made responsive.
         </li>
         <li>
-          The overflow icon appears on the right and triggers the secondary navigation
+            Responsiveness is triggered below the <code class="clr-code">768px</code> breakpoint by adding the <code class="clr-code">clr-nav-level</code> input to the navigation level.
         </li>
-      </ul>
-    </li>
-  </ul>
+        <li>
+            A <code class="clr-code">clr-nav-level</code> value of <code class="clr-code">1</code> is for primary navigation and <code class="clr-code">2</code> is for secondary navigation.
+        </li>
+        <li>
+            On small screens:
+            <ul class="list cozy-sm">
+                <li>
+                    The hamburger icon appears on the left of the header and triggers the primary navigation
+                </li>
+                <li>
+                    The overflow icon appears on the right and triggers the secondary navigation
+                </li>
+            </ul>
+        </li>
+    </ul>
 
-  <div class="alert alert-info cozy">
-    <div class="alert-item">
-        <span class="alert-text">
+    <div class="alert alert-info cozy">
+        <div class="alert-item">
+            <span class="alert-text">
             Although three levels of navigation make sense on large screens, this number of levels becomes hard to navigate on smaller screens. Clarity recommends that applications for tablets and phones are not exact replicas of the desktop versions, but rather a different, simplified experience.
         </span>
+        </div>
     </div>
-  </div>
 
-  <p><strong>Note:</strong> Responsive navigation requires you to use the following Angular components
-    to build the layout of your application:</p>
+    <p><strong>Note:</strong> Responsive navigation requires you to use the following Angular components to build the layout of your application:</p>
 
-  <ul class="list">
-    <li><code class="clr-code">clr-main-container</code></li>
-    <li><code class="clr-code">clr-header</code></li>
-  </ul>
+    <ul class="list">
+        <li><code class="clr-code">clr-main-container</code></li>
+        <li><code class="clr-code">clr-header</code></li>
+    </ul>
 
-  <h4 id="examples">Examples</h4>
+    <h4 id="examples">Examples</h4>
 
-  <h6>1. Header navigation as primary and sidenav as secondary</h6>
-  <div class="row">
-    <div class="col-xs-12">
-      <h6>Large screens</h6>
-      <img class="img-fluid cozy-sm" src="/assets/images/documentation/navigation/header_sidenav_large.png?1481774401150832000" />
+    <h6>1. Header navigation as primary and sidenav as secondary</h6>
+    <div class="row">
+        <div class="col-xs-12">
+            <h6>Large screens</h6>
+            <img class="img-fluid cozy-sm" src="/assets/images/documentation/navigation/header_sidenav_large.png?1481774401150832000" />
+        </div>
+        <div class="col-xs-12 col-sm-8 col-md-6">
+            <h6>Header navigation on small screens</h6>
+            <img class="img-fluid cozy-sm" src="/assets/images/documentation/navigation/navLevel1.gif?1481774401150832000" />
+        </div>
+        <div class="col-xs-12 col-sm-8 col-md-6">
+            <h6>Sidenav on small screens</h6>
+            <img class="img-fluid cozy-sm" src="/assets/images/documentation/navigation/navLevel2.gif?1481774401150832000" />
+        </div>
     </div>
-    <div class="col-xs-12 col-sm-8 col-md-6">
-      <h6>Header navigation on small screens</h6>
-      <img class="img-fluid cozy-sm" src="/assets/images/documentation/navigation/navLevel1.gif?1481774401150832000" />
-    </div>
-    <div class="col-xs-12 col-sm-8 col-md-6">
-      <h6>Sidenav on small screens</h6>
-      <img class="img-fluid cozy-sm" src="/assets/images/documentation/navigation/navLevel2.gif?1481774401150832000" />
-    </div>
-  </div>
 
-  <clr-responsive-nav-header-sidenav-demo></clr-responsive-nav-header-sidenav-demo>
+    <clr-responsive-nav-header-sidenav-demo></clr-responsive-nav-header-sidenav-demo>
 
-  <h6>2. Subnav as primary and sidenav as secondary</h6>
+    <h6>2. Subnav as primary and sidenav as secondary</h6>
 
-  <clr-responsive-nav-subnav-sidenav-demo></clr-responsive-nav-subnav-sidenav-demo>
+    <clr-responsive-nav-subnav-sidenav-demo></clr-responsive-nav-subnav-sidenav-demo>
 
-  <h3 id="guidelines">Designing Navigation</h3>
+    <h3 id="guidelines">Designing Navigation</h3>
 
-  <p>When establishing your navigation model, consider:</p>
+    <p>When establishing your navigation model, consider:</p>
 
-  <ul class="list">
-    <li>The key use cases of your app</li>
-    <li>The proper hierarchy and what belongs in the primary navigation versus what goes in the secondary or lower levels of navigation</li>
-    <li>Whether to orient the navigation horizontally, vertically, or both</li>
-    <li>Whether responsiveness needs to be part of your platform strategy</li>
-  </ul>
+    <ul class="list">
+        <li>The key use cases of your app</li>
+        <li>The proper hierarchy and what belongs in the primary navigation versus what goes in the secondary or lower levels of navigation</li>
+        <li>Whether to orient the navigation horizontally, vertically, or both</li>
+        <li>Whether responsiveness needs to be part of your platform strategy</li>
+    </ul>
 
-  <!-- ### Navigation Components
+    <!-- ### Navigation Components
 
   Clarity has three navigation components: header, subnav, and sidenav.  These components:
 
@@ -118,143 +118,143 @@
   - Adapt to changes in screen size according to predefined breakpoints and grid alignment. This responsiveness helps your app scale from small to large screens.
   -->
 
-  <h3 id="using-the-navigation-patterns">Using the Navigation Patterns</h3>
+    <h3 id="using-the-navigation-patterns">Using the Navigation Patterns</h3>
 
-  <h4 id="header">Header</h4>
+    <h4 id="header">Header</h4>
 
-  <div class="row">
-    <div class="col-xs-12 col-md-5">
-      <img src="/assets/images/documentation/app-layout/Header.png?1481774401150832000" alt="Header" />
+    <div class="row">
+        <div class="col-xs-12 col-md-5">
+            <img src="/assets/images/documentation/app-layout/Header.png?1481774401150832000" alt="Header" />
+        </div>
+        <div class="col-xs-12 col-md-7">
+            <div>The <a routerLink="/documentation/header">header</a> is for primary navigation. Benefits of this navigation pattern are:</div>
+            <ul class="list">
+                <li>Users often look for navigation in the header.</li>
+                <li>Top-level navigation is kept simple–the recommended number of links is 2 to 4.</li>
+                <li>Navigation does not take real estate away from the content area.</li>
+            </ul>
+            <p>
+                Conversely, the header supports other items (search and setting) and the navigation links might become crowded.
+            </p>
+        </div>
     </div>
-    <div class="col-xs-12 col-md-7">
-      <div>The <a href="/clarity/documentation/header">header</a> is for primary navigation. Benefits of this navigation pattern are:</div>
-      <ul class="list">
-        <li>Users often look for navigation in the header.</li>
-        <li>Top-level navigation is kept simple–the recommended number of links is 2 to 4.</li>
-        <li>Navigation does not take real estate away from the content area.</li>
-      </ul>
-      <p>
-        Conversely, the header supports other items (search and setting) and the navigation links might become crowded.
-      </p>
-    </div>
-  </div>
 
-  <h4 id="subnav">Subnav</h4>
+    <h4 id="subnav">Subnav</h4>
 
-  <div class="row">
-    <div class="col-xs-12 col-md-5">
-      <img src="/assets/images/documentation/app-layout/subnav.png?1481774401150832000" alt="Subnav" />
+    <div class="row">
+        <div class="col-xs-12 col-md-5">
+            <img src="/assets/images/documentation/app-layout/subnav.png?1481774401150832000" alt="Subnav" />
+        </div>
+        <div class="col-xs-12 col-md-7">
+            <div>
+                Use the <a routerLink="/documentation/header">subnav</a> for primary navigation when you need the sidebar for secondary navigation and any of the following apply:
+            </div>
+            <ul class="list">
+                <li>You have more links than can fit in the header.</li>
+                <li>The text of your links is too long for the header.</li>
+                <li>You want to limit the header to search and settings.</li>
+            </ul>
+        </div>
     </div>
-    <div class="col-xs-12 col-md-7">
-      <div>
-        Use the <a href="/clarity/documentation/header">subnav</a> for primary navigation when you need the sidebar for secondary navigation and any of the following apply:
-      </div>
-      <ul class="list">
-        <li>You have more links than can fit in the header.</li>
-        <li>The text of your links is too long for the header.</li>
-        <li>You want to limit the header to search and settings.</li>
-      </ul>
-    </div>
-  </div>
 
-  <h4 id="sidenav">Sidenav</h4>
+    <h4 id="sidenav">Sidenav</h4>
 
-  <div class="row">
-    <div class="col-xs-12 col-md-5">
-      <img src="/assets/images/documentation/app-layout/sidenav.png?1481774401150832000" alt="Sidenav" />
+    <div class="row">
+        <div class="col-xs-12 col-md-5">
+            <img src="/assets/images/documentation/app-layout/sidenav.png?1481774401150832000" alt="Sidenav" />
+        </div>
+        <div class="col-xs-12 col-md-7">
+            <div>
+                Benefits of the <a routerLink="/documentation/sidenav">sidenav</a> are that it:
+            </div>
+            <ul class="list">
+                <li>Is a familiar navigation pattern for users.</li>
+                <li>Accommodates a large number of links, becoming vertically scrollable when content exceeds the view port.</li>
+                <li>Supports progressive disclosure of a hierarchy.</li>
+                <li>Supports categorization of links.</li>
+            </ul>
+            <p>
+                Conversely, the sidenav takes real estate away from the content area. Also, on mobile, the hierarchy within the sidenav should be kept to a minimum.
+            </p>
+        </div>
     </div>
-    <div class="col-xs-12 col-md-7">
-      <div>
-        Benefits of the <a href="/clarity/documentation/sidenav">sidenav</a> are that it:
-      </div>
-      <ul class="list">
-        <li>Is a familiar navigation pattern for users.</li>
-        <li>Accommodates a large number of links, becoming vertically scrollable when content exceeds the view port.</li>
-        <li>Supports progressive disclosure of a hierarchy.</li>
-        <li>Supports categorization of links.</li>
-      </ul>
-      <p>
-        Conversely, the sidenav takes real estate away from the content area.  Also, on mobile, the hierarchy within the sidenav should be kept to a minimum.
-      </p>
-    </div>
-  </div>
 
-  <h3 id="combining-navigation-patterns">Combining Navigation Patterns</h3>
+    <h3 id="combining-navigation-patterns">Combining Navigation Patterns</h3>
 
-  <h4>Header and sidenav</h4>
-  <div class="row cozy-sm">
-    <div class="col-xs-12 col-md-5">
-      <img src="/assets/images/documentation/app-layout/header_sidenav.png?1481774401150832000" alt="Header &amp; Sidenav" />
+    <h4>Header and sidenav</h4>
+    <div class="row cozy-sm">
+        <div class="col-xs-12 col-md-5">
+            <img src="/assets/images/documentation/app-layout/header_sidenav.png?1481774401150832000" alt="Header &amp; Sidenav" />
+        </div>
+        <div class="col-xs-12 col-md-7">
+            <div>
+                A common pattern for two levels of navigation. The primary navigation is in the header, secondary in the sidenav.
+            </div>
+        </div>
     </div>
-    <div class="col-xs-12 col-md-7">
-      <div>
-        A common pattern for two levels of navigation.
-        The primary navigation is in the header, secondary in the sidenav.
-      </div>
-    </div>
-  </div>
 
-  <h4>Header and subnav</h4>
-  <div class="row cozy-sm">
-    <div class="col-xs-12 col-md-5">
-      <img src="/assets/images/documentation/app-layout/header_subnav.png?1481774401150832000" alt="Header &amp; Subnav" />
+    <h4>Header and subnav</h4>
+    <div class="row cozy-sm">
+        <div class="col-xs-12 col-md-5">
+            <img src="/assets/images/documentation/app-layout/header_subnav.png?1481774401150832000" alt="Header &amp; Subnav" />
+        </div>
+        <div class="col-xs-12 col-md-7">
+            <div>
+                Because both patterns are horizontal, use this combination only when the secondary navigation does not warrant the space taken up by the sidenav.
+            </div>
+        </div>
     </div>
-    <div class="col-xs-12 col-md-7">
-      <div>
-        Because both patterns are horizontal, use this combination only when the secondary navigation does not warrant the space taken up by the sidenav.
-      </div>
+
+    <h4>Subnav and sidenav</h4>
+    <div class="row cozy-sm">
+        <div class="col-xs-12 col-md-5">
+            <img src="/assets/images/documentation/app-layout/subnav_sidenav.png?1481774401150832000" alt="Subnav &amp; Sidenav" />
+        </div>
+        <div class="col-xs-12 col-md-7">
+            <div>
+                Use the subnav for primary navigation when the links do not fit in the header.
+            </div>
+        </div>
     </div>
-  </div>
 
-  <h4>Subnav and sidenav</h4>
-  <div class="row cozy-sm">
-    <div class="col-xs-12 col-md-5">
-      <img src="/assets/images/documentation/app-layout/subnav_sidenav.png?1481774401150832000" alt="Subnav &amp; Sidenav" />
+    <h4>Header, subnav and sidenav</h4>
+    <div class="row cozy-sm">
+        <div class="col-xs-12 col-md-5">
+            <img src="/assets/images/documentation/app-layout/header_subnav_sidenav.png?1481774401150832000" alt="Header, Subnav &amp; Sidenav" />
+        </div>
+        <div class="col-xs-12 col-md-7">
+            <div>
+                This schema will not result in a clear visual hierarchy because of the adjacent horizontal patterns. An alternative is to use the header and sidenav and then provide further navigation in the content area by using tabs.
+            </div>
+        </div>
     </div>
-    <div class="col-xs-12 col-md-7">
-      <div>
-        Use the subnav for primary navigation when the links do not fit in the header.
-      </div>
+
+    <h3 class="cozy">Responsive Navigation Layouts</h3>
+
+    <p>Responsiveness is supported for the primary and secondary levels of navigation. If your app has more than two levels of navigation, you’ll need to build a custom solution. At three levels, the navigation becomes increasingly nested and too complex
+        for Clarity to provide a single responsive solution.</p>
+
+    <p>For layouts 768px or under:</p>
+
+    <ul class="list">
+        <li>Primary navigation targets move to a hamburger menu on the left.</li>
+        <li>Secondary navigation targets move to an overflow menu on the right.</li>
+    </ul>
+
+    <div class="row cozy-sm">
+        <div class="col-xs-12">
+            <img src="/assets/images/documentation/app-layout/header_small.png?1481774401150832000" class="img-fluid" alt="Header on Small Screens" />
+        </div>
     </div>
-  </div>
 
-  <h4>Header, subnav and sidenav</h4>
-  <div class="row cozy-sm">
-    <div class="col-xs-12 col-md-5">
-      <img src="/assets/images/documentation/app-layout/header_subnav_sidenav.png?1481774401150832000" alt="Header, Subnav &amp; Sidenav" />
+    <p>When the user clicks the menu icon, a temporary side panel opens with the navigation targets. Content is not accessible while the panel is open.</p>
+
+    <div class="row">
+        <div class="col-xs-12 col-sm-12 col-md-6 cozy-sm">
+            <img src="/assets/images/documentation/app-layout/header_nav_level_2.png?1481774401150832000" class="img-fluid" alt="Header Triggers Pressed" />
+        </div>
+        <div class="col-xs-12 col-sm-12 col-md-6 cozy-sm">
+            <img src="/assets/images/documentation/app-layout/header_nav_level_1.png?1481774401150832000" class="img-fluid" alt="Header Triggers Pressed" />
+        </div>
     </div>
-    <div class="col-xs-12 col-md-7">
-      <div>
-        This schema will not result in a clear visual hierarchy because of the adjacent horizontal patterns. An alternative is to use the header and sidenav and then provide further navigation in the content area by using tabs.
-      </div>
-    </div>
-  </div>
-
-  <h3 class="cozy">Responsive Navigation Layouts</h3>
-
-  <p>Responsiveness is supported for the primary and secondary levels of navigation.  If your app has more than two levels of navigation, you’ll need to build a custom solution.  At three levels, the navigation becomes increasingly nested and too complex for Clarity to provide a single responsive solution.</p>
-
-  <p>For layouts 768px or under:</p>
-
-  <ul class="list">
-    <li>Primary navigation targets move to a hamburger menu on the left.</li>
-    <li>Secondary navigation targets move to an overflow menu on the right.</li>
-  </ul>
-
-  <div class="row cozy-sm">
-    <div class="col-xs-12">
-      <img src="/assets/images/documentation/app-layout/header_small.png?1481774401150832000" class="img-fluid" alt="Header on Small Screens" />
-    </div>
-  </div>
-
-  <p>When the user clicks the menu icon, a temporary side panel opens with the navigation targets. Content is not accessible while the panel is open.</p>
-
-  <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-6 cozy-sm">
-      <img src="/assets/images/documentation/app-layout/header_nav_level_2.png?1481774401150832000" class="img-fluid" alt="Header Triggers Pressed" />
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-6 cozy-sm">
-      <img src="/assets/images/documentation/app-layout/header_nav_level_1.png?1481774401150832000" class="img-fluid" alt="Header Triggers Pressed" />
-    </div>
-  </div>
 </article>

--- a/src/pages/documentation/progress.html
+++ b/src/pages/documentation/progress.html
@@ -1,121 +1,129 @@
+<article>
+    <h5 class="component-summary" id="a-progress-bar-is-a-linear-indicator-for-providing-feedback-about-an-ongoing-user-initiated-process">A progress bar is a linear indicator for providing feedback about an ongoing, user-initiated process.</h5>
 
-<article><h5 class="component-summary" id="a-progress-bar-is-a-linear-indicator-for-providing-feedback-about-an-ongoing-user-initiated-process">A progress bar is a linear indicator for providing feedback about an ongoing, user-initiated process.</h5>
+    <p>Progress bars consist of an HTML5 progress element inside the block-level element with the <code class="clr-code">.progress</code> classname. The block-level container is necessary due to cross-browser constraints with styling HTML5 progress elements.
+        As browsers improve, the intent is for this container to go away.</p>
 
-  <p>Progress bars consist of an HTML5 progress element inside the block-level element with the <code class="clr-code">.progress</code> classname. The block-level container is necessary due to cross-browser constraints with styling HTML5 progress elements. As browsers improve, the intent is for this container to go away.</p>
+    <clr-progress-bar-examples-demo class="clrweb-progress-demo"></clr-progress-bar-examples-demo>
 
-  <clr-progress-bar-examples-demo class="clrweb-progress-demo"></clr-progress-bar-examples-demo>
+    <h3 id="indeterminate-looping-progress-bars">Indeterminate (Looping) Progress Bars</h3>
 
-  <h3 id="indeterminate-looping-progress-bars">Indeterminate (Looping) Progress Bars</h3>
+    <p>When the amount of time a task will take is not known, use an indeterminate (or looping) progress bar. These progress bars feature a recurring animation that continues until the task is complete and the progress bar is no longer needed.</p>
 
-  <p>When the amount of time a task will take is not known, use an indeterminate (or looping) progress bar. These progress bars feature a recurring animation that continues until the task is complete and the progress bar is no longer needed.</p>
+    <clr-progress-bar-loop-demo class="clrweb-progress-demo"></clr-progress-bar-loop-demo>
 
-  <clr-progress-bar-loop-demo class="clrweb-progress-demo"></clr-progress-bar-loop-demo>
+    <h3 id="color">Color</h3>
 
-  <h3 id="color">Color</h3>
+    <p>The default color of the fill bar is Action Blue. You can change the color as follows:</p>
 
-  <p>The default color of the fill bar is Action Blue.  You can change the color as follows:</p>
+    <ul class="list">
+        <li>Green for success</li>
+        <li>Red to indicate danger or warning</li>
+    </ul>
 
-  <ul class="list">
-    <li>Green for success</li>
-    <li>Red to indicate danger or warning</li>
-  </ul>
+    <clr-progress-bar-colors-demo class="clrweb-progress-demo"></clr-progress-bar-colors-demo>
 
-  <clr-progress-bar-colors-demo class="clrweb-progress-demo"></clr-progress-bar-colors-demo>
+    <h3 id="animation">Animation</h3>
 
-  <h3 id="animation">Animation</h3>
+    <p>Progress bars have options for animation.</p>
 
-  <p>Progress bars have options for animation.</p>
+    <ul class="list">
+        <li>Use fade animation when you want the progress bar to disappear with a fade.</li>
+        <li>Use flash animation to draw the user’s attention when the process has completed.</li>
+    </ul>
 
-  <ul class="list">
-    <li>Use fade animation when you want the progress bar to disappear with a fade.</li>
-    <li>Use flash animation to draw the user’s attention when the process has completed.</li>
-  </ul>
+    <clr-progress-bar-animations-demo class="clrweb-progress-demo"></clr-progress-bar-animations-demo>
 
-  <clr-progress-bar-animations-demo class="clrweb-progress-demo"></clr-progress-bar-animations-demo>
+    <h3 id="variations">Variations</h3>
+    <p>The animation, color, and type of a progress bar can be changed by adding or removing CSS classes from the following list of class names.</p>
 
-  <h3 id="variations">Variations</h3>
-  <p>The animation, color, and type of a progress bar can be changed by adding or removing CSS classes from the following list of class names.</p>
+    <ul class="list">
+        <li><strong>labeled:</strong> A progress container with the <code class="clr-code">labeled</code> classname will show the percent complete as a numerical percentage to the far right of the progress bar. Note that this requires a <code class="clr-code">&lt;span&gt;</code>            element be placed within the container after the <code class="clr-code">&lt;progress&gt;</code>. You will also need to update the contents of the span programmatically.</li>
+        <li><strong>progress-fade:</strong> A progress container with the <code class="clr-code">progress-fade</code> classname will fade out after it reaches 100%.</li>
+        <li><strong>flash:</strong> A progress container with the <code class="clr-code">flash</code> classname will have the bar color change to green after it reaches 100%. This can be combined with the <code class="clr-code">progress-fade</code> classname
+            to have the bar change color to green and then fade out.</li>
+        <li><strong>flash-danger:</strong> A progress container with the <code class="clr-code">flash-danger</code> classname will have the bar color change to red after it reaches 100%. This classname can also be combined with the <code class="clr-code">progress-fade</code>            classname.</li>
+        <li><strong>loop:</strong> A progress container with the <code class="clr-code">loop</code> classname will show a progress bar that loops across infinitely. This is the style for our indeterminate progress bar.</li>
+        <li><strong>danger:</strong> A progress container with the <code class="clr-code">danger</code> classname will show up as red.</li>
+        <li><strong>warning:</strong> A progress container with the <code class="clr-code">warning</code> classname will also show up as red.</li>
+        <li><strong>success:</strong> A progress container with the <code class="clr-code">success</code> classname will show up as green.</li>
+    </ul>
 
-  <ul class="list">
-    <li><strong>labeled:</strong> A progress container with the <code class="clr-code">labeled</code> classname will show the percent complete as a numerical percentage to the far right of the progress bar. Note that this requires a <code class="clr-code">&lt;span&gt;</code> element be placed within the container after the <code class="clr-code">&lt;progress&gt;</code>. You will also need to update the contents of the span programmatically.</li>
-    <li><strong>progress-fade:</strong> A progress container with the <code class="clr-code">progress-fade</code> classname will fade out after it reaches 100%.</li>
-    <li><strong>flash:</strong> A progress container with the <code class="clr-code">flash</code> classname will have the bar color change to green after it reaches 100%. This can be combined with the <code class="clr-code">progress-fade</code> classname to have the bar change color to green and then fade out.</li>
-    <li><strong>flash-danger:</strong> A progress container with the <code class="clr-code">flash-danger</code> classname will have the bar color change to red after it reaches 100%. This classname can also be combined with the <code class="clr-code">progress-fade</code> classname.</li>
-    <li><strong>loop:</strong> A progress container with the <code class="clr-code">loop</code> classname will show a progress bar that loops across infinitely. This is the style for our indeterminate progress bar.</li>
-    <li><strong>danger:</strong> A progress container with the <code class="clr-code">danger</code> classname will show up as red.</li>
-    <li><strong>warning:</strong> A progress container with the <code class="clr-code">warning</code> classname will also show up as red.</li>
-    <li><strong>success:</strong> A progress container with the <code class="clr-code">success</code> classname will show up as green.</li>
-  </ul>
+    <h3 id="progress-bar-in-cards">Progress Bar in Cards</h3>
 
-  <h3 id="progress-bar-in-cards">Progress Bar in Cards</h3>
+    <clr-progress-bar-cards-demo class="clrweb-progress-demo"></clr-progress-bar-cards-demo>
 
-  <clr-progress-bar-cards-demo class="clrweb-progress-demo"></clr-progress-bar-cards-demo>
+    <h3 id="static-progress-bar-in-cards">Static Progress Bar in Cards</h3>
 
-  <h3 id="static-progress-bar-in-cards">Static Progress Bar in Cards</h3>
+    <clr-progress-bar-static-cards-demo class="clrweb-progress-demo"></clr-progress-bar-static-cards-demo>
 
-  <clr-progress-bar-static-cards-demo class="clrweb-progress-demo"></clr-progress-bar-static-cards-demo>
+    <h3 id="progress-bar-in-sidebar-navigation">Progress Bar in Sidebar Navigation</h3>
 
-  <h3 id="progress-bar-in-sidebar-navigation">Progress Bar in Sidebar Navigation</h3>
+    <clr-progress-bar-sidenav-demo class="clrweb-progress-demo"></clr-progress-bar-sidenav-demo>
 
-  <clr-progress-bar-sidenav-demo class="clrweb-progress-demo"></clr-progress-bar-sidenav-demo>
+    <h3 id="static-progress-bars">Static Progress Bars</h3>
 
-  <h3 id="static-progress-bars">Static Progress Bars</h3>
+    <p>Some applications use progress bars inside other widgets that re-render repeatedly in the DOM. While this is not a pattern that Clarity promotes, we have implemented a “static” progress bar to assist in these uses.</p>
 
-  <p>Some applications use progress bars inside other widgets that re-render repeatedly in the DOM. While this is not a pattern that Clarity promotes, we have implemented a “static” progress bar to assist in these uses.</p>
+    <p>A normal progress bar will animate from its starting point to the defined ending point. When widgets that contain progress bars are re-rendered in the DOM, this results in Clarity’s progress bars continually growing from zero to the defined value.</p>
 
-  <p>A normal progress bar will animate from its starting point to the defined ending point. When widgets that contain progress bars are re-rendered in the DOM, this results in Clarity’s progress bars continually growing from zero to the defined value.</p>
+    <p>A static progress bar just shows the defined value. It does not animate and lend itself to these sorts of DOM refreshes.</p>
 
-  <p>A static progress bar just shows the defined value. It does not animate and lend itself to these sorts of DOM refreshes.</p>
+    <p>Because there was no way to turn off the animation in IE/Edge’s implementation of the HTML5 progress element, there is a related, though separate, component for static progress bars.</p>
 
-  <p>Because there was no way to turn off the animation in IE/Edge’s implementation of the HTML5 progress element, there is a related, though separate, component for static progress bars.</p>
+    <clr-progress-bar-static-demo class="clrweb-progress-demo"></clr-progress-bar-static-demo>
 
-  <clr-progress-bar-static-demo class="clrweb-progress-demo"></clr-progress-bar-static-demo>
+    <ul class="list">
+        <li>Instead of a <code>.progress</code> container <code>div</code>, the static progress bar has a <code>.progress-static</code> container <code>div</code>.</li>
+        <li>Instead of a <code>progress</code> element inside the container, there is a <code>div&lt;/codeAtom&gt; with the class of <code>.progress-meter</code> applied to it.</code>
+        </li>
+        <li>A <code>div</code> cannot have a value attribute, so the <code>.progress-meter</code> element has <code>data-value</code> attribute. The completion value must be dynamically inserted in the <code>data-value</code> attribute.</li>
+        <li>The <code>data-value</code> attribute must contain an integer between 0 and 100.</li>
+    </ul>
 
-  <ul class="list">
-    <li>Instead of a <code>.progress</code> container <code>div</code>, the static progress bar has a <code>.progress-static</code> container <code>div</code>.</li>
-    <li>Instead of a <code>progress</code> element inside the container, there is a <code>div&lt;/codeAtom&gt; with the class of <code>.progress-meter</code> applied to it.</code></li>
-    <li>A <code>div</code> cannot have a value attribute, so the <code>.progress-meter</code> element has <code>data-value</code> attribute. The completion value must be dynamically inserted in the <code>data-value</code> attribute.</li>
-    <li>The <code>data-value</code> attribute must contain an integer between 0 and 100.</li>
-  </ul>
+    <h3 id="progress-bar-blocks-and-groups">Progress Bar Blocks and Groups</h3>
 
-  <h3 id="progress-bar-blocks-and-groups">Progress Bar Blocks and Groups</h3>
+    <p>Progress bar blocks allow for <code class="clr-code">label</code> and <code class="clr-code">span</code> elements to be placed alongside the <code class="clr-code">.progress</code> and <code class="clr-code">.progress-static</code> element. The progress
+        bar block is a wrapper element with the <code class="clr-code">.progress-block</code> classname applied to it.</p>
 
-  <p>Progress bar blocks allow for <code class="clr-code">label</code> and <code class="clr-code">span</code> elements to be placed alongside the <code class="clr-code">.progress</code> and <code class="clr-code">.progress-static</code> element. The progress bar block is a wrapper element with the <code class="clr-code">.progress-block</code> classname applied to it.</p>
+    <p>Progress bar groups allow for vertical stacking of elements above and below the progress bar. To create a progress bar group, wrap the <code class="clr-code">.progress</code> and <code class="clr-code">.progress-static</code> element with a
+        <code
+            class="clr-code">.progress-group</code> element.</p>
 
-  <p>Progress bar groups allow for vertical stacking of elements above and below the progress bar. To create a progress bar group, wrap the <code class="clr-code">.progress</code> and <code class="clr-code">.progress-static</code> element with a <code class="clr-code">.progress-group</code> element.</p>
+    <clr-progress-bar-inline-demo class="clrweb-progress-demo"></clr-progress-bar-inline-demo>
 
-  <clr-progress-bar-inline-demo class="clrweb-progress-demo"></clr-progress-bar-inline-demo>
+    <p>Progress bar blocks are also available for use inside of Clarity cards.</p>
 
-  <p>Progress bar blocks are also available for use inside of Clarity cards.</p>
+    <clr-progress-bar-inline-cards-demo class="clrweb-progress-demo"></clr-progress-bar-inline-cards-demo>
 
-  <clr-progress-bar-inline-cards-demo class="clrweb-progress-demo"></clr-progress-bar-inline-cards-demo>
+    <h3 id="guidelines">Usage</h3>
 
-  <h3 id="guidelines">Usage</h3>
+    <p>Clarity has two types of progress bars:</p>
 
-  <p>Clarity has two types of progress bars:</p>
+    <ul class="list">
+        <li>A determinate progress bar, which shows process completion from 0 to 100%. Use this progress bar for a process of known duration.</li>
+        <li>An indeterminate progress bar, which animates continuously until the process is complete. Use this progress bar for a process for which there is no estimate of the end time.</li>
+    </ul>
 
-  <ul class="list">
-    <li>A determinate progress bar, which shows process completion from 0 to 100%.  Use this progress bar for a process of known duration.</li>
-    <li>An indeterminate progress bar, which animates continuously until the process is complete.  Use this progress bar for a process for which there is no estimate of the end time.</li>
-  </ul>
+    <h4 id="placement">Placement</h4>
 
-  <h4 id="placement">Placement</h4>
+    <p>Progress bars are designed for use in the main content area, <a routerLink="/documentation/header">header</a>, <a routerLink="/documentation/cards">cards</a>, and <a routerLink="/documentation/modals">modals</a>. The size of the progress bar adjusts
+        to its container. Indicate which process is being monitored through placement of the progress bar in the container.</p>
 
-  <p>Progress bars are designed for use in the main content area, <a href="/clarity/documentation/header">header</a>,  <a href="/clarity/documentation/cards">cards</a>, and <a href="/clarity/documentation/modals">modals</a>.  The size of the progress bar adjusts to its container.  Indicate which process is being monitored through placement of the progress bar in the container.</p>
+    <h4 id="messaging">Messaging</h4>
 
-  <h4 id="messaging">Messaging</h4>
+    <p>Use messaging as follows:</p>
 
-  <p>Use messaging as follows:</p>
+    <ul class="list">
+        <li>For a determinate progress bar, use a label to show percentage complete.</li>
+        <li>For an indeterminate progress indicator, add messaging to let the user know the operation is in progress, for example, “Working…,” or “Loading update 3 of 7.”</li>
+        <li>Keep the messaging minimal.</li>
+    </ul>
 
-  <ul class="list">
-    <li>For a determinate progress bar, use a label to show percentage complete.</li>
-    <li>For an indeterminate progress indicator, add messaging to let the user know the operation is in progress, for example, “Working…,” or “Loading update 3 of 7.”</li>
-    <li>Keep the messaging minimal.</li>
-  </ul>
+    <p>Clarity places the label on the right of the progress bar because the bar fills from left to right.</p>
 
-  <p>Clarity places the label on the right of the progress bar because the bar fills from left to right.</p>
+    <h4 id="progress-bar-versus-spinner">Progress Bar Versus Spinner</h4>
 
-  <h4 id="progress-bar-versus-spinner">Progress Bar Versus Spinner</h4>
-
-  <p>Clarity also has a circular progress indicator, called a <a href="/clarity/documentation/spinners">spinner</a>, which serves the same use case as an indeterminate progress bar.  Using a spinner or an indeterminate progress bar is a matter of available space and activation point. In many cases, spinners are best because they occupy less space.</p>
+    <p>Clarity also has a circular progress indicator, called a <a routerLink="/documentation/spinners">spinner</a>, which serves the same use case as an indeterminate progress bar. Using a spinner or an indeterminate progress bar is a matter of available
+        space and activation point. In many cases, spinners are best because they occupy less space.</p>
 </article>

--- a/src/pages/documentation/radios.html
+++ b/src/pages/documentation/radios.html
@@ -1,14 +1,14 @@
+<article>
+    <h5 class="component-summary" id="with-radio-buttons-users-can-select-one-option-in-a-group-of-options">With radio buttons, users can select one option in a group of options.</h5>
 
-<article><h5 class="component-summary" id="with-radio-buttons-users-can-select-one-option-in-a-group-of-options">With radio buttons, users can select one option in a group of options.</h5>
+    <clr-radios-demo></clr-radios-demo>
 
-  <clr-radios-demo></clr-radios-demo>
+    <h3 id="guidelines">Usage</h3>
 
-  <h3 id="guidelines">Usage</h3>
+    <p>Use radio buttons when you want users to see all available options and the list of options is small. For mutually exclusive options, consider a <a routerLink="/documentation/checkboxes">checkbox</a> or <a routerLink="/documentation/toggle-switches">toggle switch</a>.</p>
 
-  <p>Use radio buttons when you want users to see all available options and the list of options is small.  For mutually exclusive options, consider a <a href="/clarity/documentation/checkboxes">checkbox</a> or <a href="/clarity/documentation/toggle-switches">toggle switch</a>.</p>
-
-  <ul class="list">
-    <li>Radio buttons are best for six or fewer options.</li>
-    <li>For more than six options, consider a <a href="/clarity/documentation/select-boxes">select box</a>, which prompts users to disclose the options.</li>
-  </ul>
+    <ul class="list">
+        <li>Radio buttons are best for six or fewer options.</li>
+        <li>For more than six options, consider a <a routerLink="/documentation/select-boxes">select box</a>, which prompts users to disclose the options.</li>
+    </ul>
 </article>

--- a/src/pages/documentation/select-boxes.html
+++ b/src/pages/documentation/select-boxes.html
@@ -1,23 +1,24 @@
+<article>
+    <h5 class="component-summary" id="with-a-select-box-users-can-select-one-item-from-a-list-of-values-the-selected-item-is-visible-when-the-select-box-is-closed">With a select box, users can select one item from a list of values. The selected item is visible when the select box is closed.</h5>
 
-<article><h5 class="component-summary" id="with-a-select-box-users-can-select-one-item-from-a-list-of-values-the-selected-item-is-visible-when-the-select-box-is-closed">With a select box, users can select one item from a list of values. The selected item is visible when the select box is closed.</h5>
+    <p>Select boxes are a <code class="clr-code">select</code> element with its <code class="clr-code">option</code>s wrapped in a block element with the <code class="clr-code">.select</code> classname applied to it. To use a select box within a form, it
+        can be wrapped in another block element with the <code class="clr-code">.form-group</code> classname.</p>
 
-  <p>Select boxes are a <code class="clr-code">select</code> element with its <code class="clr-code">option</code>s wrapped in a block element with the <code class="clr-code">.select</code> classname applied to it. To use a select box within a form, it can be wrapped in another block element with the <code class="clr-code">.form-group</code> classname.</p>
+    <clr-selects-demo></clr-selects-demo>
 
-  <clr-selects-demo></clr-selects-demo>
+    <h3 id="guidelines">Usage</h3>
 
-  <h3 id="guidelines">Usage</h3>
+    <p>Use a select box for a list of items that a user does not need to see all the time.</p>
 
-  <p>Use a select box for a list of items that a user does not need to see all the time.</p>
+    <p>A common strategy is to combine an input field with a select box so that a user can enter a value and qualify it with a menu item. For example, the user might enter a number in an input field and select the units from the select box.</p>
 
-  <p>A common strategy is to combine an input field with a select box so that a user can enter a value and qualify it with a menu item.  For example, the user might enter a number in an input field and select the units from the select box.</p>
+    <p>Don’t confuse a select box with a <a routerLink="/documentation/dropdowns">dropdown menu</a>. Select boxes are for setting options and work best in forms. Dropdowns are for presenting actions and most appropriate in a header.</p>
 
-  <p>Don’t confuse a select box with a <a href="/clarity/documentation/dropdowns">dropdown menu</a>.  Select boxes are for setting options and work best in forms.  Dropdowns are for presenting actions and most appropriate in a header.</p>
+    <h4 id="number-of-list-items">Number of List Items</h4>
 
-  <h4 id="number-of-list-items">Number of List Items</h4>
+    <p>Typically, a select box contains between 3 and 12 items. For fewer than 3 items or to present choices that are always visible, consider a <a routerLink="/documentation/radios">radio button</a>.</p>
 
-  <p>Typically, a select box contains between 3 and 12 items.  For fewer than 3 items or to present choices that are always visible, consider a <a href="/clarity/documentation/radios">radio button</a>.</p>
+    <h4 id="label">Label</h4>
 
-  <h4 id="label">Label</h4>
-
-  <p>A select box requires a brief introductory label that describes the items in the menu. Use sentence-style capitalization for both the label and the menu items.</p>
+    <p>A select box requires a brief introductory label that describes the items in the menu. Use sentence-style capitalization for both the label and the menu items.</p>
 </article>

--- a/src/pages/documentation/spinners.html
+++ b/src/pages/documentation/spinners.html
@@ -1,93 +1,93 @@
+<article>
+    <h5 class="component-summary" id="a-spinner-is-visual-indicator-of-an-ongoing-user-initiated-process">A spinner is visual indicator of an ongoing, user-initiated process.</h5>
 
-<article><h5 class="component-summary" id="a-spinner-is-visual-indicator-of-an-ongoing-user-initiated-process">A spinner is visual indicator of an ongoing, user-initiated process.</h5>
+    <p>Clarity has two types of spinners:</p>
 
-  <p>Clarity has two types of spinners:</p>
+    <ul class="list">
+        <li><strong>Page Spinners:</strong> For tracking the progress of an operation related to an entire page.</li>
+        <li><strong>Inline Spinners:</strong> For tracking the progress of an operation related to a specific component.</li>
+    </ul>
 
-  <ul class="list">
-    <li><strong>Page Spinners:</strong> For tracking the progress of an operation related to an entire page.</li>
-    <li><strong>Inline Spinners:</strong> For tracking the progress of an operation related to a specific component.</li>
-  </ul>
+    <h6 id="spinner">.spinner</h6>
 
-  <h6 id="spinner">.spinner</h6>
+    <p>Use the <code class="clr-code">.spinner</code> to create a page spinner.</p>
 
-  <p>Use the <code class="clr-code">.spinner</code> to create a page spinner.</p>
+    <h6 id="spinner-inline">.spinner-inline</h6>
 
-  <h6 id="spinner-inline">.spinner-inline</h6>
+    <p>Extend the <code class="clr-code">.spinner-inline</code> class with <code class="clr-code">.spinner</code> to create an inline spinner.</p>
 
-  <p>Extend the <code class="clr-code">.spinner-inline</code> class with <code class="clr-code">.spinner</code> to create an inline spinner.</p>
+    <h6 id="spinner-inverse">.spinner-inverse</h6>
 
-  <h6 id="spinner-inverse">.spinner-inverse</h6>
+    <p>Extend the <code>.spinner-inverse</code> class with <code>.spinner</code> to create a spinner for dark backgrounds.</p>
 
-  <p>Extend the <code>.spinner-inverse</code> class with <code>.spinner</code> to create a spinner for dark backgrounds.</p>
+    <h3 id="examples">Examples</h3>
 
-  <h3 id="examples">Examples</h3>
+    <clr-spinner-types></clr-spinner-types>
 
-  <clr-spinner-types></clr-spinner-types>
+    <h3 id="spinner-sizes">Spinner Sizes</h3>
 
-  <h3 id="spinner-sizes">Spinner Sizes</h3>
+    <p>Clarity spinners can be displayed in three sizes:</p>
 
-  <p>Clarity spinners can be displayed in three sizes:</p>
+    <ul class="list">
+        <li><strong>Small:</strong> This is the required sizing for inline spinners (see above). It measures 18x18 pixels.</li>
+        <li><strong>Medium:</strong> Medium spinners measure 36x36 pixels.</li>
+        <li><strong>Large:</strong> This is the default size for page spinners (see above).</li>
+    </ul>
 
-  <ul class="list">
-    <li><strong>Small:</strong> This is the required sizing for inline spinners (see above). It measures 18x18 pixels.</li>
-    <li><strong>Medium:</strong> Medium spinners measure 36x36 pixels.</li>
-    <li><strong>Large:</strong> This is the default size for page spinners (see above).</li>
-  </ul>
+    <h6 id="spinner-sizes-classnames">Spinner sizes classnames</h6>
 
-  <h6 id="spinner-sizes-classnames">Spinner sizes classnames</h6>
+    <p>The classnames used to size spinners are: <code class="clr-code">.spinner-sm</code>, <code class="clr-code">.spinner-md</code>, and <code class="clr-code">.spinner-lg</code>. Note that using the <code class="clr-code">.spinner-inline</code> class
+        will force a spinner to the small size and that <code class="clr-code">.spinner-lg</code> is the default sizing of page spinners.</p>
 
-  <p>The classnames used to size spinners are: <code class="clr-code">.spinner-sm</code>, <code class="clr-code">.spinner-md</code>, and <code class="clr-code">.spinner-lg</code>. Note that using the <code class="clr-code">.spinner-inline</code> class will force a spinner to the small size and that <code class="clr-code">.spinner-lg</code> is the default sizing of page spinners.</p>
+    <h3 id="examples-1">Examples</h3>
 
-  <h3 id="examples-1">Examples</h3>
+    <clr-spinner-sizes></clr-spinner-sizes>
 
-  <clr-spinner-sizes></clr-spinner-sizes>
+    <h3 id="guidelines">Usage</h3>
 
-  <h3 id="guidelines">Usage</h3>
+    <p>Use the three sizes of spinners as follows:</p>
 
-  <p>Use the three sizes of spinners as follows:</p>
+    <table class="table table-noborder">
+        <tbody>
+            <tr>
+                <td class="left">
+                    <b>Large</b>
+                    <div class="hidden-sm-up nowrap">72px &times; 72px</div>
+                </td>
+                <td class="left hidden-xs-down nowrap">72px &times; 72px</td>
+                <td class="left">
+                    Use to track the progress of an operation related to a page. For example, in the login form, a large spinner replaces the form fields while the data is being authenticated.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <b>Medium</b>
+                    <div class="hidden-sm-up nowrap">36px &times; 36px</div>
+                </td>
+                <td class="left hidden-xs-down nowrap">36px &times; 36px</td>
+                <td class="left">Use when content is being loaded, for example, in a table or datagrid.</td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <b>Small</b>
+                    <div class="hidden-sm-up">18px &times; 18px</div>
+                </td>
+                <td class="left hidden-xs-down">18px &times; 18px</td>
+                <td class="left">Use in constrained spaces, such as in an input field or next to a button. The spinner animates and the field or button is disabled until the action is complete.</td>
+            </tr>
+        </tbody>
+    </table>
 
-  <table class="table table-noborder">
-    <tbody>
-    <tr>
-      <td class="left">
-        <b>Large</b>
-        <div class="hidden-sm-up nowrap">72px &times; 72px</div>
-      </td>
-      <td class="left hidden-xs-down nowrap">72px &times; 72px</td>
-      <td class="left">
-        Use to track the progress of an operation related to a page.
-        For example, in the login form, a large spinner replaces the
-        form fields while the data is being authenticated.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <b>Medium</b>
-        <div class="hidden-sm-up nowrap">36px &times; 36px</div>
-      </td>
-      <td class="left hidden-xs-down nowrap">36px &times; 36px</td>
-      <td class="left">Use when content is being loaded, for example, in a table or datagrid.</td>
-    </tr>
-    <tr>
-      <td class="left">
-        <b>Small</b>
-        <div class="hidden-sm-up">18px &times; 18px</div>
-      </td>
-      <td class="left hidden-xs-down">18px &times; 18px</td>
-      <td class="left">Use in constrained spaces, such as in an input field or next to a button.  The spinner animates and the field or button is disabled until the action is complete.</td>
-    </tr>
-    </tbody>
-  </table>
+    <h4 id="placement">Placement</h4>
 
-  <h4 id="placement">Placement</h4>
+    <p>Place the spinner where you want to focus users’ attention when the process completes.</p>
 
-  <p>Place the spinner where you want to focus users’ attention when the process completes.</p>
+    <h4 id="label">Label</h4>
 
-  <h4 id="label">Label</h4>
+    <p>Optionally, provide a brief description of the process, for example, “Loading …”</p>
 
-  <p>Optionally, provide a brief description of the process, for example, “Loading …”</p>
+    <h4 id="spinners-versus-progress-bars">Spinners Versus Progress Bars</h4>
 
-  <h4 id="spinners-versus-progress-bars">Spinners Versus Progress Bars</h4>
-
-  <p>Clarity provides a linear, indeterminate <a href="/clarity/documentation/progress">progress bar</a> that serves the same use cases as a spinner.  Using a spinner or an indeterminate progress bar is a matter of spacing, visual consistency, and the object the user selected to begin the process.</p>
+    <p>Clarity provides a linear, indeterminate <a routerLink="/documentation/progress">progress bar</a> that serves the same use cases as a spinner. Using a spinner or an indeterminate progress bar is a matter of spacing, visual consistency, and the object
+        the user selected to begin the process.</p>
 </article>

--- a/src/pages/documentation/tabs.html
+++ b/src/pages/documentation/tabs.html
@@ -1,187 +1,184 @@
+<article>
+    <h5 class="component-summary" id="tabs-divide-content-into-separate-views-which-users-navigate-between">Tabs divide content into separate views which users navigate between.</h5>
 
-<article><h5 class="component-summary" id="tabs-divide-content-into-separate-views-which-users-navigate-between">Tabs divide content into separate views which users navigate between.</h5>
+    <h3 id="static">Static</h3>
 
-  <h3 id="static">Static</h3>
+    <h6 id="basic-example">Basic example</h6>
 
-  <h6 id="basic-example">Basic example</h6>
+    <p>The following is a static example of tabs with their associated sections. The active tab should have the additional class <code class="clr-code">active</code>.</p>
 
-  <p>The following is a static example of tabs with their associated sections. The active tab should have the additional class <code class="clr-code">active</code>.</p>
+    <p>The stylesheet will hide all the section elements where attribute <code class="clr-code">aria-hidden</code> is set to <code class="clr-code">true</code>.</p>
 
-  <p>The stylesheet will hide all the section elements where attribute <code class="clr-code">aria-hidden</code> is set to <code class="clr-code">true</code>.</p>
+    <h6 id="accessibility">Accessibility</h6>
 
-  <h6 id="accessibility">Accessibility</h6>
+    <p>The active tab should have the attribute <code class="clr-code">aria-selected</code> set to <code class="clr-code">true</code>, and the others to false.</p>
 
-  <p>The active tab should have the attribute <code class="clr-code">aria-selected</code> set to <code class="clr-code">true</code>, and the others to false.</p>
+    <p>The active panel associated with the active tab should have the attribute <code class="clr-code">aria-hidden</code> set to <code class="clr-code">true</code>, and the others <code class="clr-code">to false</code>.</p>
 
-  <p>The active panel associated with the active tab should have the attribute <code class="clr-code">aria-hidden</code> set to <code class="clr-code">true</code>, and the others <code class="clr-code">to false</code>.</p>
+    <p>In addition, each tab should have an aria-controls attribute set to the id of the matching panel and each panel should have an <code class="clr-code">aria-labelledby</code> attribute set to the id of the tab associated with the panel.</p>
 
-  <p>In addition, each tab should have an aria-controls attribute set to the id of the matching panel and each panel should have an <code class="clr-code">aria-labelledby</code> attribute set to the id of the tab associated with the panel.</p>
+    <clr-tabs-demo-static></clr-tabs-demo-static>
 
-  <clr-tabs-demo-static></clr-tabs-demo-static>
+    <h3 id="angular-component">Angular Component</h3>
 
-  <h3 id="angular-component">Angular Component</h3>
+    <h6 id="basic-example-1">Basic example</h6>
 
-  <h6 id="basic-example-1">Basic example</h6>
+    <p>The tabs component is generated based on the <code class="clr-code">&lt;clr-tab-link&gt;</code> and <code class="clr-code">&lt;clr-tab-content&gt;</code> sub-components inside the <code class="clr-code">&lt;clr-tabs&gt;</code> tag. The tab links are
+        automatically associated with the content components, in order. If there are more tabs then content sections, clicking on the extra tabs will set the tab to active but only show blank content. If there are more content sections than tabs, the
+        extra sections will remain invisible since no tab can be selected to activate them.</p>
 
-  <p>The tabs component is generated based on the <code class="clr-code">&lt;clr-tab-link&gt;</code> and <code class="clr-code">&lt;clr-tab-content&gt;</code> sub-components inside the <code class="clr-code">&lt;clr-tabs&gt;</code> tag. The tab links are automatically associated with the content components, in order. If there are more tabs then content sections, clicking on the extra tabs will set the tab to active but  only show blank content. If there are more content sections than tabs, the extra sections will remain invisible since no tab can be selected to activate them.</p>
+    <h6 id="accessibility-1">Accessibility</h6>
 
-  <h6 id="accessibility-1">Accessibility</h6>
+    <p>All attributes associated with accessibility (aria-controls, aria-selected, aria-hidden, aria-labelledby, role) are automatically created and managed by the angular component.</p>
 
-  <p>All attributes associated with accessibility (aria-controls, aria-selected, aria-hidden, aria-labelledby, role) are automatically created and managed by the angular component.</p>
+    <clr-modal-tabs-angular></clr-modal-tabs-angular>
 
-  <clr-modal-tabs-angular></clr-modal-tabs-angular>
+    <h3 id="summary-of-options">Summary of Options</h3>
 
-  <h3 id="summary-of-options">Summary of Options</h3>
+    <table class="table">
+        <thead>
+            <tr>
+                <th class="left">Input/Output</th>
+                <th class="hidden-xs-down">Values</th>
+                <th class="hidden-xs-down">Default</th>
+                <th class="left">Effect</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td class="left">
+                    <b>[clrTabContentActive]</b>
+                    <div class="hidden-sm-up">Type: Boolean</div>
+                    <div class="hidden-sm-up">Default: false</div>
+                </td>
+                <td class="hidden-xs-down">true, false</td>
+                <td class="hidden-xs-down">false</td>
+                <td class="left">
+                    Used on &lt;clr-tab-content&gt;. If true, will make the content visible. If none of the &lt;clr-tab-content&gt;s are set as active, then the component will initialize the first one as active. Note that while it's possible to set multiple tab contents
+                    as active, it is discouraged.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <b>[clrTabContentId]</b>
+                    <div class="hidden-sm-up">Values:<br />&lt;any valid id for html element&gt;</div>
+                    <div class="hidden-sm-up">Default: auto-generated</div>
+                </td>
+                <td class="hidden-xs-down">&lt;any valid id for html element&gt;</td>
+                <td class="hidden-xs-down">auto-generated</td>
+                <td class="left">
+                    Used on &lt;clr-tab-content&gt;. If explicitly set, will assign the set id as the id for the element. If not set, the component will auto-generate the id.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <div class="hidden-xs-down"><b>[clrTabsCurrentTabIndex]</b></div>
+                    <div class="hidden-sm-up"><b>[clrTabs<br />CurrentTabIndex]</b></div>
+                    <div class="hidden-sm-up">Type: Integer</div>
+                    <div class="hidden-sm-up">Default: -1</div>
+                </td>
+                <td class="hidden-xs-down">&lt;number&gt;</td>
+                <td class="hidden-xs-down">-1</td>
+                <td class="left">
+                    Returns the index of the current active tab link. If multiple tab links are active, this will return the index of the last active tab link.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <b>[clrTabLinkActive]</b>
+                    <div class="hidden-sm-up">Type: Boolean</div>
+                    <div class="hidden-sm-up">Default: false</div>
+                </td>
+                <td class="hidden-xs-down">true, false</td>
+                <td class="hidden-xs-down">false</td>
+                <td class="left">
+                    Used on &lt;clr-tab-link&gt;. If true, will highlight the tab as an active tab. If none of the &lt;clr-tab-link&gt;s is set as active, then the component will initialize the first one as active. Note that while it's possible to set multiple tab links
+                    as active, it is discouraged.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <b>[clrTabLinkId]</b>
+                    <div class="hidden-sm-up">Values:<br />&lt;any valid id for html element&gt;</div>
+                    <div class="hidden-sm-up">Default: auto-generated</div>
+                </td>
+                <td class="hidden-xs-down">&lt;any valid id for html element&gt;</td>
+                <td class="hidden-xs-down">auto-generated</td>
+                <td class="left">
+                    Used on &lt;clr-tab-link&gt;. If explicitly set, will assign the set id as the id for the element. If not set, the component will auto-generate the id.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <div class="hidden-xs-down"><b>(clrTabsCurrentTabLinkChanged)</b></div>
+                    <div class="hidden-sm-up"><b>(clrTabsCurrent<br />TabLinkChanged)</b></div>
+                    <div class="hidden-sm-up">Type: TabLink object</div>
+                </td>
+                <td class="hidden-xs-down">&lt;TabLink&gt;</td>
+                <td class="hidden-xs-down">N/A</td>
+                <td class="left">
+                    When a tab is clicked, an event is emitted with the selected TabLink.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <div class="hidden-xs-down"><b>(clrTabsCurrentTabContentChanged)</b></div>
+                    <div class="hidden-sm-up"><b>(clrTabsCurrent<br />TabContentChanged)</b></div>
+                    <div class="hidden-sm-up">Type: TabContent object</div>
+                </td>
+                <td class="hidden-xs-down">&lt;TabContent&gt;</td>
+                <td class="hidden-xs-down">N/A</td>
+                <td class="left">
+                    When a tab is clicked, an event with the TabContent whose index matches the selected TabLink is emitted.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <div class="hidden-xs-down"><b>(clrTabsCurrentTabIndexChanged)</b></div>
+                    <div class="hidden-sm-up"><b>(clrTabsCurrent<br />TabIndexChanged)</b></div>
+                    <div class="hidden-sm-up">Type: Integer</div>
+                </td>
+                <td class="hidden-xs-down">&lt;number&gt;</td>
+                <td class="hidden-xs-down">N/A</td>
+                <td class="left">
+                    When a tab is clicked, an event with the index of the selected TabLink is emitted .
+                </td>
+            </tr>
+        </tbody>
+    </table>
 
-  <table class="table">
-    <thead>
-    <tr>
-      <th class="left">Input/Output</th>
-      <th class="hidden-xs-down">Values</th>
-      <th class="hidden-xs-down">Default</th>
-      <th class="left">Effect</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr>
-      <td class="left">
-        <b>[clrTabContentActive]</b>
-        <div class="hidden-sm-up">Type: Boolean</div>
-        <div class="hidden-sm-up">Default: false</div>
-      </td>
-      <td class="hidden-xs-down">true, false</td>
-      <td class="hidden-xs-down">false</td>
-      <td class="left">
-        Used on &lt;clr-tab-content&gt;. If true, will make the content visible. If none of the
-        &lt;clr-tab-content&gt;s are set as active, then the component will initialize the first one as active.
-        Note that while it's possible to set multiple tab contents as active, it is discouraged.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <b>[clrTabContentId]</b>
-        <div class="hidden-sm-up">Values:<br />&lt;any valid id for html element&gt;</div>
-        <div class="hidden-sm-up">Default: auto-generated</div>
-      </td>
-      <td class="hidden-xs-down">&lt;any valid id for html element&gt;</td>
-      <td class="hidden-xs-down">auto-generated</td>
-      <td class="left">
-        Used on &lt;clr-tab-content&gt;. If explicitly set, will assign the set id as the id for the element. If not set,
-        the component will auto-generate the id.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <div class="hidden-xs-down"><b>[clrTabsCurrentTabIndex]</b></div>
-        <div class="hidden-sm-up"><b>[clrTabs<br />CurrentTabIndex]</b></div>
-        <div class="hidden-sm-up">Type: Integer</div>
-        <div class="hidden-sm-up">Default: -1</div>
-      </td>
-      <td class="hidden-xs-down">&lt;number&gt;</td>
-      <td class="hidden-xs-down">-1</td>
-      <td class="left">
-        Returns the index of the current active tab link. If multiple tab links are active, this will return the
-        index of the last active tab link.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <b>[clrTabLinkActive]</b>
-        <div class="hidden-sm-up">Type: Boolean</div>
-        <div class="hidden-sm-up">Default: false</div>
-      </td>
-      <td class="hidden-xs-down">true, false</td>
-      <td class="hidden-xs-down">false</td>
-      <td class="left">
-        Used on &lt;clr-tab-link&gt;. If true, will highlight the tab as an active tab. If none of the
-        &lt;clr-tab-link&gt;s is set as active, then the component will initialize the first one as active.
-        Note that while it's possible to set multiple tab links as active, it is discouraged.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <b>[clrTabLinkId]</b>
-        <div class="hidden-sm-up">Values:<br />&lt;any valid id for html element&gt;</div>
-        <div class="hidden-sm-up">Default: auto-generated</div>
-      </td>
-      <td class="hidden-xs-down">&lt;any valid id for html element&gt;</td>
-      <td class="hidden-xs-down">auto-generated</td>
-      <td class="left">
-        Used on &lt;clr-tab-link&gt;. If explicitly set, will assign the set id as the id for the element. If not set,
-        the component will auto-generate the id.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <div class="hidden-xs-down"><b>(clrTabsCurrentTabLinkChanged)</b></div>
-        <div class="hidden-sm-up"><b>(clrTabsCurrent<br />TabLinkChanged)</b></div>
-        <div class="hidden-sm-up">Type: TabLink object</div>
-      </td>
-      <td class="hidden-xs-down">&lt;TabLink&gt;</td>
-      <td class="hidden-xs-down">N/A</td>
-      <td class="left">
-        When a tab is clicked, an event is emitted with the selected TabLink.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <div class="hidden-xs-down"><b>(clrTabsCurrentTabContentChanged)</b></div>
-        <div class="hidden-sm-up"><b>(clrTabsCurrent<br />TabContentChanged)</b></div>
-        <div class="hidden-sm-up">Type: TabContent object</div>
-      </td>
-      <td class="hidden-xs-down">&lt;TabContent&gt;</td>
-      <td class="hidden-xs-down">N/A</td>
-      <td class="left">
-        When a tab is clicked, an event  with the TabContent whose index matches the selected TabLink is emitted.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <div class="hidden-xs-down"><b>(clrTabsCurrentTabIndexChanged)</b></div>
-        <div class="hidden-sm-up"><b>(clrTabsCurrent<br />TabIndexChanged)</b></div>
-        <div class="hidden-sm-up">Type: Integer</div>
-      </td>
-      <td class="hidden-xs-down">&lt;number&gt;</td>
-      <td class="hidden-xs-down">N/A</td>
-      <td class="left">
-        When a tab is clicked, an event with the index of the selected TabLink is emitted .
-      </td>
-    </tr>
-    </tbody>
-  </table>
+    <h3 id="guidelines">Usage</h3>
 
-  <h3 id="guidelines">Usage</h3>
+    <p>Use tabs for alternate views within the <a routerLink="/documentation/sidenav">sidenav</a> or main content area.</p>
 
-  <p>Use tabs for alternate views within the <a href="/clarity/documentation/sidenav">sidenav</a> or main content area.</p>
+    <p>Don’t use tabs to break user interactions into a series of steps. Serial workflows are best presented in a <a routerLink="/documentation/wizards">wizard</a>.</p>
 
-  <p>Don’t use tabs to break user interactions into a series of steps.  Serial workflows are best presented in a <a href="/clarity/documentation/wizards">wizard</a>.</p>
+    <p>Avoid using tabs in cards and modals.</p>
 
-  <p>Avoid using tabs in cards and modals.</p>
+    <h3 id="presentation">Presentation</h3>
 
-  <h3 id="presentation">Presentation</h3>
+    <p>Tabs appear in a single, non-scrollable row, above their content. The width of each tab is dependent on its label.</p>
 
-  <p>Tabs appear in a single, non-scrollable row, above their content.  The width of each tab is dependent on its label.</p>
+    <p>To ensure that all tabs appear in the container, avoid using more than seven tabs and limit labels to one or two words.</p>
 
-  <p>To ensure that all tabs appear in the container, avoid using more than seven tabs and limit labels to  one or two words.</p>
+    <h3 id="content">Content</h3>
 
-  <h3 id="content">Content</h3>
+    <p>While the content within tabs is flexible, follow these guidelines for organization and presentation:</p>
 
-  <p>While the content within tabs is flexible, follow these guidelines for organization and presentation:</p>
+    <ul class="list">
+        <li>Ensure that the content in each view is independent of the content in other views.</li>
+        <li>Don’t force users to navigate back and forth to compare data–keep such content in the same view.</li>
+        <li>Avoid cross-linking between tabs.</li>
+        <li>If the content within a view is broad, divide it into subsections.</li>
+    </ul>
 
-  <ul class="list">
-    <li>Ensure that the content in each view is independent of the content in other views.</li>
-    <li>Don’t force users to navigate back and forth to compare data–keep such content in the same view.</li>
-    <li>Avoid cross-linking between tabs.</li>
-    <li>If the content within a view is broad, divide it into subsections.</li>
-  </ul>
+    <h3 id="labels">Labels</h3>
 
-  <h3 id="labels">Labels</h3>
-
-  <ul class="list">
-    <li>Ensure that the labels show a clear relationship between views.</li>
-    <li>Favor nouns over verbs, for example, Settings, Permissions, and Performance.</li>
-    <li>Avoid generic labels such as General or Advanced.</li>
-    <li>Use title-style caps.</li>
-    <li>Avoid using icons in labels.</li>
-  </ul>
+    <ul class="list">
+        <li>Ensure that the labels show a clear relationship between views.</li>
+        <li>Favor nouns over verbs, for example, Settings, Permissions, and Performance.</li>
+        <li>Avoid generic labels such as General or Advanced.</li>
+        <li>Use title-style caps.</li>
+        <li>Avoid using icons in labels.</li>
+    </ul>
 </article>

--- a/src/pages/documentation/toggle-switches.html
+++ b/src/pages/documentation/toggle-switches.html
@@ -1,27 +1,27 @@
+<article>
+    <h5 class="component-summary" id="a-toggle-switch-changes-on-and-off-states-of-a-single-setting">A toggle switch changes on and off states of a single setting.</h5>
 
-<article><h5 class="component-summary" id="a-toggle-switch-changes-on-and-off-states-of-a-single-setting">A toggle switch changes on and off states of a single setting.</h5>
+    <p>To create a toggle switch, wrap an <code class="clr-code">input[type="checkbox"]</code> element and a <code class="clr-code">label</code> element in a block-level wrapper (like a <code class="clr-code">div</code>) with the <code class="clr-code">.toggle-switch</code>        classname. To use a toggle without any label, keep the <code class="clr-code">label</code> tag empty. The default toggle is gray in its “off” state and green in its “on” state. The user can change states by clicking on either the toggle or its
+        accompanying label.</p>
 
-  <p>To create a toggle switch, wrap an <code class="clr-code">input[type="checkbox"]</code> element and a <code class="clr-code">label</code> element in a block-level wrapper (like a <code class="clr-code">div</code>) with the <code class="clr-code">.toggle-switch</code> classname. To use a toggle without any label, keep the <code class="clr-code">label</code> tag empty.
-    The default toggle is gray in its “off” state and green in its “on” state. The user can change states by clicking on either the toggle or its accompanying label.</p>
+    <h3 id="disabled-toggles">Disabled Toggles</h3>
 
-  <h3 id="disabled-toggles">Disabled Toggles</h3>
+    <p>To disable a toggle switch, add the <code class="clr-code">disabled</code> attribute to the toggle’s <code class="clr-code">checkbox</code> input. When disabled, the toggle appears gray. The user cannot change the state of the toggle. And the present
+        state is reflected in both the location of the toggle switch and by the “on” state being a slightly darker gray.</p>
 
-  <p>To disable a toggle switch, add the <code class="clr-code">disabled</code> attribute to the toggle’s <code class="clr-code">checkbox</code> input.
-    When disabled, the toggle appears gray. The user cannot change the state of the toggle. And the present state is reflected in both the location of the toggle switch and by the “on” state being a slightly darker gray.</p>
+    <clr-toggles-demo></clr-toggles-demo>
 
-  <clr-toggles-demo></clr-toggles-demo>
+    <h3 id="guidelines">Usage</h3>
 
-  <h3 id="guidelines">Usage</h3>
+    <p>Use a toggle switch when you need the sole options of “on” and “off.”</p>
 
-  <p>Use a toggle switch when you need the sole options of “on” and “off.”</p>
+    <p>Toggle switches take up less space than an “on/off” <a routerLink="/documentation/radios">radio button group</a> and communicate their intended purpose better than a <a routerLink="/documentation/checkboxes">checkbox</a> that toggles functionality.</p>
 
-  <p>Toggle switches take up less space than an “on/off” <a href="/clarity/documentation/radios">radio button group</a> and communicate their intended purpose better than a <a href="/clarity/documentation/checkboxes">checkbox</a> that toggles functionality.</p>
+    <h4 id="toggle-states">Toggle States</h4>
 
-  <h4 id="toggle-states">Toggle States</h4>
+    <p>Toggle switches do not include “ON” and “OFF” text because these states are clearly implied.</p>
 
-  <p>Toggle switches do not include “ON” and “OFF” text because these states are clearly implied.</p>
+    <h4 id="label">Label</h4>
 
-  <h4 id="label">Label</h4>
-
-  <p>The label should clearly describe the setting.  Although Clarity supports a toggle switch without a label, use this approach only if the purpose of the control is made clear elsewhere, for example, in a group label or section header.</p>
+    <p>The label should clearly describe the setting. Although Clarity supports a toggle switch without a label, use this approach only if the purpose of the control is made clear elsewhere, for example, in a group label or section header.</p>
 </article>

--- a/src/pages/documentation/typography.html
+++ b/src/pages/documentation/typography.html
@@ -1,39 +1,41 @@
+<article>
+    <h5 class="component-summary" id="clarity-uses-the-geometric-sans-serif-font-metropolis">Clarity uses the geometric sans-serif font, Metropolis.</h5>
 
-<article><h5 class="component-summary" id="clarity-uses-the-geometric-sans-serif-font-metropolis">Clarity uses the geometric sans-serif font, Metropolis.</h5>
+    <h3 id="text-styles">Text Styles</h3>
 
-  <h3 id="text-styles">Text Styles</h3>
+    <clr-typography-text></clr-typography-text>
 
-  <clr-typography-text></clr-typography-text>
+    <h3 id="header-styles">Header Styles</h3>
 
-  <h3 id="header-styles">Header Styles</h3>
+    <clr-typography-headers></clr-typography-headers>
 
-  <clr-typography-headers></clr-typography-headers>
+    <h3 id="using-typography">Using Typography</h3>
 
-  <h3 id="using-typography">Using Typography</h3>
+    <p>Clarity includes several SASS variables, collections, mixing, and functions for working with typography. These are described below:</p>
 
-  <p>Clarity includes several SASS variables, collections, mixing, and functions for working with typography. These are described below:</p>
+    <h6 id="clr-font">$clr-font</h6>
 
-  <h6 id="clr-font">$clr-font</h6>
+    <p>This SASS variable points to our default text font, Metropolis.</p>
 
-  <p>This SASS variable points to our default text font, Metropolis.</p>
+    <h6 id="clr-altfont">$clr-altFont</h6>
 
-  <h6 id="clr-altfont">$clr-altFont</h6>
+    <p>This SASS variable is only used for our headers (H1..H6). Currently, it also points to Metropolis.</p>
 
-  <p>This SASS variable is only used for our headers (H1..H6). Currently, it also points to Metropolis.</p>
+    <h6 id="clr-font-size">$clr-font-size</h6>
 
-  <h6 id="clr-font-size">$clr-font-size</h6>
+    <p>This SASS variable sets our default font size to 14px.</p>
 
-  <p>This SASS variable sets our default font size to 14px.</p>
+    <h6 id="clr-font-weights">$clr-font-weights</h6>
 
-  <h6 id="clr-font-weights">$clr-font-weights</h6>
+    <p>This SASS variable contains a collection for the font weights used in Clarity — light, regular, semibold, and bold. The actual weights assigned to these values are 200, 400, 500, and 600 respectively. The default font weight in Clarity is regular/400.
+        The bold font-weight is actually Metropolis semi-bold (600).</p>
 
-  <p>This SASS variable contains a collection for the font weights used in Clarity — light, regular, semibold, and bold. The actual weights assigned to these values are 200, 400, 500, and 600 respectively. The default font weight in Clarity is regular/400. The bold font-weight is actually Metropolis semi-bold (600).</p>
+    <h6 id="clr-elements">$clr-elements</h6>
 
-  <h6 id="clr-elements">$clr-elements</h6>
+    <p>This SASS variable contains a collection that can access all of the font properties for H1 through H6 and P1 through P8 as defined in our typography specs. These properties are returned as a collection which contains nested collections of both common
+        font properties across all screen sizes, as well as breakpoint overrides.</p>
 
-  <p>This SASS variable contains a collection that can access all of the font properties for H1 through H6 and P1 through P8 as defined in our typography specs. These properties are returned as a collection which contains nested collections of both common font properties across all screen sizes, as well as breakpoint overrides.</p>
-
-  <pre>
+    <pre>
 <code class="language-scss">
     // passing element label to map-get
     map-get($clr-elements, h3);
@@ -62,55 +64,56 @@
 </code>
 </pre>
 
-  <h6 id="clr-typography-dom-to-type-element">$clr-typography-dom-to-type-element</h6>
+    <h6 id="clr-typography-dom-to-type-element">$clr-typography-dom-to-type-element</h6>
 
-  <p>This collection maps Clarity components and DOM containers to their expected type properties in <code>$clr-elements</code>. Use the labels listed in the <em>Use For</em> column of the typography tables above.</p>
+    <p>This collection maps Clarity components and DOM containers to their expected type properties in <code>$clr-elements</code>. Use the labels listed in the <em>Use For</em> column of the typography tables above.</p>
 
-  <h4 id="mixins">Mixins</h4>
+    <h4 id="mixins">Mixins</h4>
 
-  <p>Clarity uses SASS mixins to make it easier to access the type properties in the variables and collections listed above. The typography mixins return full CSS style definitions. They are intended to be used inside SASS/SCSS style declarations, placeholders, or other mixins.</p>
+    <p>Clarity uses SASS mixins to make it easier to access the type properties in the variables and collections listed above. The typography mixins return full CSS style definitions. They are intended to be used inside SASS/SCSS style declarations, placeholders,
+        or other mixins.</p>
 
-  <h6 class="hidden-xs-down" id="clr-gettypepropertieselement-whichtypeproperties">clr-getTypeProperties($element, $whichTypeProperties)</h6>
+    <h6 class="hidden-xs-down" id="clr-gettypepropertieselement-whichtypeproperties">clr-getTypeProperties($element, $whichTypeProperties)</h6>
 
-  <h6 class="hidden-sm-up" id="clr-gettypeproperties">clr-getTypeProperties</h6>
+    <h6 class="hidden-sm-up" id="clr-gettypeproperties">clr-getTypeProperties</h6>
 
-  <p>Returns specified styles (from <code>$whichTypeProperties</code> list parameter) for all styles from the designated typographic element (h1..h6 or p1..p8).</p>
+    <p>Returns specified styles (from <code>$whichTypeProperties</code> list parameter) for all styles from the designated typographic element (h1..h6 or p1..p8).</p>
 
-  <h6 id="parameters">Parameters</h6>
+    <h6 id="parameters">Parameters</h6>
 
-  <div>
-    <table class="table">
-      <thead>
-      <tr>
-        <th class="left">Parameter</th>
-        <th class="left hidden-xs-down">Optional</th>
-        <th class="left">Purpose</th>
-        <th class="left hidden-xs-down">Default</th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr>
-        <td class="left">$element</td>
-        <td class="left hidden-xs-down">No</td>
-        <td class="left">Key for the typographic properties in the <code class="clr-code">$clr-elements</code> map. <code class="clr-code">h1..h6</code> or <code class="clr-code">p1..p8</code></td>
-        <td class="left hidden-xs-down">&nbsp;</td>
-      </tr>
-      <tr>
-        <td class="left">
-          $whichTypeProperties
-          <div class="hidden-sm-up">(Optional)</div>
-        </td>
-        <td class="left hidden-xs-down">Yes</td>
-        <td class="left">A list of font style properties like <code class="clr-code">(font-weight, line-height)</code>. If empty, all properties will be returned.</td>
-        <td class="left hidden-xs-down">An empty list</td>
-      </tr>
-      </tbody>
-    </table>
-  </div>
+    <div>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th class="left">Parameter</th>
+                    <th class="left hidden-xs-down">Optional</th>
+                    <th class="left">Purpose</th>
+                    <th class="left hidden-xs-down">Default</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td class="left">$element</td>
+                    <td class="left hidden-xs-down">No</td>
+                    <td class="left">Key for the typographic properties in the <code class="clr-code">$clr-elements</code> map. <code class="clr-code">h1..h6</code> or <code class="clr-code">p1..p8</code></td>
+                    <td class="left hidden-xs-down">&nbsp;</td>
+                </tr>
+                <tr>
+                    <td class="left">
+                        $whichTypeProperties
+                        <div class="hidden-sm-up">(Optional)</div>
+                    </td>
+                    <td class="left hidden-xs-down">Yes</td>
+                    <td class="left">A list of font style properties like <code class="clr-code">(font-weight, line-height)</code>. If empty, all properties will be returned.</td>
+                    <td class="left hidden-xs-down">An empty list</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 
-  <h6 id="example">Example</h6>
+    <h6 id="example">Example</h6>
 
-  <pre>
+    <pre>
 <code class="language-scss">
 
     // passing type property list
@@ -142,47 +145,47 @@
 </code>
 </pre>
 
-  <h6 class="hidden-xs-down" id="clr-gettypepropertiesfordomelementelement-label-typepropertiestoget">clr-getTypePropertiesForDomElement($element-label, $typePropertiesToGet)</h6>
+    <h6 class="hidden-xs-down" id="clr-gettypepropertiesfordomelementelement-label-typepropertiestoget">clr-getTypePropertiesForDomElement($element-label, $typePropertiesToGet)</h6>
 
-  <h6 class="hidden-sm-up" id="clr-gettypepropertiesfordomelement">clr-getTypePropertiesForDomElement</h6>
+    <h6 class="hidden-sm-up" id="clr-gettypepropertiesfordomelement">clr-getTypePropertiesForDomElement</h6>
 
-  <p>An include that abstracts the clr-getTypeProperties mixin so that users can look up typography based on how it is used in Clarity.</p>
+    <p>An include that abstracts the clr-getTypeProperties mixin so that users can look up typography based on how it is used in Clarity.</p>
 
-  <h6 id="parameters-1">Parameters</h6>
+    <h6 id="parameters-1">Parameters</h6>
 
-  <div>
-    <table class="table">
-      <thead>
-      <tr>
-        <th class="left">Parameter</th>
-        <th class="left hidden-xs-down">Optional</th>
-        <th class="left">Purpose</th>
-        <th class="left hidden-xs-down">Default</th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr>
-        <td class="left">$element-label</td>
-        <td class="left hidden-xs-down">No</td>
-        <td class="left">Key/label for the element as found in the <code class="clr-code">$clr-typography-dom-to-type-element</code> map. Existing labels can be found in the <em>Use For</em> column of the header and body text tables above.</td>
-        <td class="left hidden-xs-down">&nbsp;</td>
-      </tr>
-      <tr>
-        <td class="left">
-          $typePropertiesToGet
-          <div class="hidden-sm-up">(Optional)</div>
-        </td>
-        <td class="left hidden-xs-down">Yes</td>
-        <td class="left">A list of font style properties like <code class="clr-code">(font-weight, line-height)</code>. If empty, all properties will be returned.</td>
-        <td class="left hidden-xs-down">An empty list</td>
-      </tr>
-      </tbody>
-    </table>
-  </div>
+    <div>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th class="left">Parameter</th>
+                    <th class="left hidden-xs-down">Optional</th>
+                    <th class="left">Purpose</th>
+                    <th class="left hidden-xs-down">Default</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td class="left">$element-label</td>
+                    <td class="left hidden-xs-down">No</td>
+                    <td class="left">Key/label for the element as found in the <code class="clr-code">$clr-typography-dom-to-type-element</code> map. Existing labels can be found in the <em>Use For</em> column of the header and body text tables above.</td>
+                    <td class="left hidden-xs-down">&nbsp;</td>
+                </tr>
+                <tr>
+                    <td class="left">
+                        $typePropertiesToGet
+                        <div class="hidden-sm-up">(Optional)</div>
+                    </td>
+                    <td class="left hidden-xs-down">Yes</td>
+                    <td class="left">A list of font style properties like <code class="clr-code">(font-weight, line-height)</code>. If empty, all properties will be returned.</td>
+                    <td class="left hidden-xs-down">An empty list</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 
-  <h6 id="example-1">Example</h6>
+    <h6 id="example-1">Example</h6>
 
-  <pre>
+    <pre>
 <code class="language-scss">
 
     // passing type property list
@@ -215,45 +218,46 @@
 </code>
 </pre>
 
-  <h4 id="functions">Functions</h4>
+    <h4 id="functions">Functions</h4>
 
-  <p>Clarity also includes functions that allow you to access typographic properties to assign them to your own style properties or SASS variables.</p>
+    <p>Clarity also includes functions that allow you to access typographic properties to assign them to your own style properties or SASS variables.</p>
 
-  <h6 class="hidden-xs-down" id="clr-gettypepropertyvalueelement-label-valtoget">clr-getTypePropertyValue($element-label, $valToGet)</h6>
+    <h6 class="hidden-xs-down" id="clr-gettypepropertyvalueelement-label-valtoget">clr-getTypePropertyValue($element-label, $valToGet)</h6>
 
-  <h6 id="clr-gettypepropertyvalue">clr-getTypePropertyValue</h6>
+    <h6 id="clr-gettypepropertyvalue">clr-getTypePropertyValue</h6>
 
-  <p>Returns specified style value (from <code>$valToGet</code>) from styles for the designated typographic element (h1..h6 or p1..p8). Returns an empty string <code>""</code> if the typographic element does not have the style for which it was asked or if it is passed invalid values.</p>
+    <p>Returns specified style value (from <code>$valToGet</code>) from styles for the designated typographic element (h1..h6 or p1..p8). Returns an empty string <code>""</code> if the typographic element does not have the style for which it was asked or
+        if it is passed invalid values.</p>
 
-  <h6 id="parameters-2">Parameters</h6>
+    <h6 id="parameters-2">Parameters</h6>
 
-  <div>
-    <table class="table">
-      <thead>
-      <tr>
-        <th class="left">Parameter</th>
-        <th class="left hidden-xs-down">Optional</th>
-        <th class="left">Purpose</th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr>
-        <td class="left">$element-label</td>
-        <td class="left hidden-xs-down">No</td>
-        <td class="left">Key for the typographic properties in the <code class="clr-code">$clr-elements</code> map. <code class="clr-code">h1..h6</code> or <code class="clr-code">p1..p8</code></td>
-      </tr>
-      <tr>
-        <td class="left">$valToGet</td>
-        <td class="left hidden-xs-down">No</td>
-        <td class="left">A CSS style property from the list of font style properties like <code class="clr-code">font-size</code>, <code class="clr-code">font-weight</code>, etc.</td>
-      </tr>
-      </tbody>
-    </table>
-  </div>
+    <div>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th class="left">Parameter</th>
+                    <th class="left hidden-xs-down">Optional</th>
+                    <th class="left">Purpose</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td class="left">$element-label</td>
+                    <td class="left hidden-xs-down">No</td>
+                    <td class="left">Key for the typographic properties in the <code class="clr-code">$clr-elements</code> map. <code class="clr-code">h1..h6</code> or <code class="clr-code">p1..p8</code></td>
+                </tr>
+                <tr>
+                    <td class="left">$valToGet</td>
+                    <td class="left hidden-xs-down">No</td>
+                    <td class="left">A CSS style property from the list of font style properties like <code class="clr-code">font-size</code>, <code class="clr-code">font-weight</code>, etc.</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 
-  <h6 id="example-2">Example</h6>
+    <h6 id="example-2">Example</h6>
 
-  <pre>
+    <pre>
 <code class="language-scss">
 
     // passing type property list
@@ -270,43 +274,44 @@
 </code>
 </pre>
 
-  <h6 class="hidden-xs-down" id="clr-gettypepropertyvaluefordomelementelement-label-valtoget">clr-getTypePropertyValueForDomElement($element-label, $valToGet)</h6>
+    <h6 class="hidden-xs-down" id="clr-gettypepropertyvaluefordomelementelement-label-valtoget">clr-getTypePropertyValueForDomElement($element-label, $valToGet)</h6>
 
-  <h6 class="hidden-sm-up" id="clr-gettypepropertyvaluefordomelement">clr-getTypePropertyValueForDomElement</h6>
+    <h6 class="hidden-sm-up" id="clr-gettypepropertyvaluefordomelement">clr-getTypePropertyValueForDomElement</h6>
 
-  <p>This SASS function serves as an abstraction of the <code>clr-getTypePropertyValue</code> above. It performs a lookup against the <code>$clr-typography-dom-to-type-element</code> map so that users can use more familiar component/DOM element labels (as listed in the tables above) to access style property values.</p>
+    <p>This SASS function serves as an abstraction of the <code>clr-getTypePropertyValue</code> above. It performs a lookup against the <code>$clr-typography-dom-to-type-element</code> map so that users can use more familiar component/DOM element labels
+        (as listed in the tables above) to access style property values.</p>
 
-  <p>The function returns a specified style value (from <code>$valToGet</code>) from styles for the designated DOM element label (like page_mainHeading). Returns an empty string <code>""</code> if the DOM element or the style is not found.</p>
+    <p>The function returns a specified style value (from <code>$valToGet</code>) from styles for the designated DOM element label (like page_mainHeading). Returns an empty string <code>""</code> if the DOM element or the style is not found.</p>
 
-  <h6 id="parameters-3">Parameters</h6>
+    <h6 id="parameters-3">Parameters</h6>
 
-  <div>
-    <table class="table">
-      <thead>
-      <tr>
-        <th class="left">Parameter</th>
-        <th class="left hidden-xs-down">Optional</th>
-        <th class="left">Purpose</th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr>
-        <td class="left">$element-label</td>
-        <td class="left hidden-xs-down">No</td>
-        <td class="left">Key/label for the element as found in the <code class="clr-code">$clr-typography-dom-to-type-element</code> map. Existing labels can be found in the <em>Use For</em> column of the header and body text tables above.</td>
-      </tr>
-      <tr>
-        <td class="left">$valToGet</td>
-        <td class="left hidden-xs-down">No</td>
-        <td class="left">A CSS style property from the list of font style properties like <code class="clr-code">font-size</code>, <code class="clr-code">font-weight</code>, etc.</td>
-      </tr>
-      </tbody>
-    </table>
-  </div>
+    <div>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th class="left">Parameter</th>
+                    <th class="left hidden-xs-down">Optional</th>
+                    <th class="left">Purpose</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td class="left">$element-label</td>
+                    <td class="left hidden-xs-down">No</td>
+                    <td class="left">Key/label for the element as found in the <code class="clr-code">$clr-typography-dom-to-type-element</code> map. Existing labels can be found in the <em>Use For</em> column of the header and body text tables above.</td>
+                </tr>
+                <tr>
+                    <td class="left">$valToGet</td>
+                    <td class="left hidden-xs-down">No</td>
+                    <td class="left">A CSS style property from the list of font style properties like <code class="clr-code">font-size</code>, <code class="clr-code">font-weight</code>, etc.</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 
-  <h6 id="example-3">Example</h6>
+    <h6 id="example-3">Example</h6>
 
-  <pre>
+    <pre>
 <code class="language-scss">
 
     // passing type property list
@@ -323,26 +328,25 @@
 </code>
 </pre>
 
-  <h3 id="guidelines">The Metropolis Font</h3>
+    <h3 id="guidelines">The Metropolis Font</h3>
 
-  <p>Metropolis has clear, simple letters with rounded forms. <br />
-    This gives the font a friendly and modern appearance.</p>
+    <p>Metropolis has clear, simple letters with rounded forms. <br /> This gives the font a friendly and modern appearance.</p>
 
-  <p><img src="/assets/images/documentation/typography/Typography-A-Z.png?1481774870417534000" alt="Metropolis light, regular, medium, and semibold" /></p>
+    <p><img src="/assets/images/documentation/typography/Typography-A-Z.png?1481774870417534000" alt="Metropolis light, regular, medium, and semibold" /></p>
 
-  <h3 id="font-weights-in-clarity">Font Weights in Clarity</h3>
+    <h3 id="font-weights-in-clarity">Font Weights in Clarity</h3>
 
-  <p>To maintain a light, clean look, Clarity does not use a weight stronger than semibold.</p>
+    <p>To maintain a light, clean look, Clarity does not use a weight stronger than semibold.</p>
 
-  <p><img src="/assets/images/documentation/typography/Typography-Metropolis.png?1481774870417534000" alt="Metropolis light, regular, medium, and semibold" /></p>
+    <p><img src="/assets/images/documentation/typography/Typography-Metropolis.png?1481774870417534000" alt="Metropolis light, regular, medium, and semibold" /></p>
 
-  <h3 id="use-the-built-in-styles">Use the Built-in Styles</h3>
+    <h3 id="use-the-built-in-styles">Use the Built-in Styles</h3>
 
-  <p>The Clarity team determined the optimal height and weight of the text for each component.   Some components also have line wrapping built-in.  If not, text should be kept to a single line.</p>
+    <p>The Clarity team determined the optimal height and weight of the text for each component. Some components also have line wrapping built-in. If not, text should be kept to a single line.</p>
 
-  <h3 id="use-text-links-for-navigation">Use Text Links for Navigation</h3>
+    <h3 id="use-text-links-for-navigation">Use Text Links for Navigation</h3>
 
-  <clr-typography-links></clr-typography-links>
+    <clr-typography-links></clr-typography-links>
 
-  <p>Don’t use text links for a call to action. <a href="/clarity/documentation/buttons">Buttons</a> are better.</p>
+    <p>Don’t use text links for a call to action. <a routerLink="/documentation/buttons">Buttons</a> are better.</p>
 </article>

--- a/src/pages/documentation/wizards.html
+++ b/src/pages/documentation/wizards.html
@@ -1,339 +1,315 @@
+<article>
+    <h5 class="component-summary" id="a-wizard-presents-a-multi-step-workflow-that-users-perform-in-a-recommended-sequence">A wizard presents a multi-step workflow that users perform in a recommended sequence.</h5>
 
-<article><h5 class="component-summary" id="a-wizard-presents-a-multi-step-workflow-that-users-perform-in-a-recommended-sequence">A wizard presents a multi-step workflow that users perform in a recommended sequence.</h5>
+    <h3 id="html-and-styles">HTML and Styles</h3>
 
-  <h3 id="html-and-styles">HTML and Styles</h3>
+    <p>Here is an example static markup using just HTML and CSS. Since the interactive functionality of the wizard is not provided in the static version, we recommend using the Angular component.</p>
 
-  <p>Here is an example static markup using just HTML and CSS. Since the interactive functionality
-    of the wizard is not provided in the static version, we recommend using the Angular component.</p>
+    <clr-wizard-demo-static></clr-wizard-demo-static>
 
-  <clr-wizard-demo-static></clr-wizard-demo-static>
+    <h2 id="angular-component">Angular Component</h2>
 
-  <h2 id="angular-component">Angular Component</h2>
+    <h3 id="basic-wizard">Basic Wizard</h3>
 
-  <h3 id="basic-wizard">Basic Wizard</h3>
+    <p>The wizard comes in three different sizes: medium, large, and extra-large. You can set the size by providing the value as an input (<code class="clr-code">clrWizardSize</code>). If not specified, the wizard will default to the extra-large size. See
+        the options table for a list of valid values for the size.</p>
 
-  <p>The wizard comes in three different sizes: medium, large, and extra-large.
-    You can set the size by providing the value as an input (<code class="clr-code">clrWizardSize</code>).
-    If not specified, the wizard will default to the extra-large size. See the options
-    table for a list of valid values for the size.</p>
+    <clr-wizard-basic></clr-wizard-basic>
 
-  <clr-wizard-basic></clr-wizard-basic>
+    <h3 id="wizard-options">Wizard Options</h3>
 
-  <h3 id="wizard-options">Wizard Options</h3>
+    <h4 id="skipping-and-unskipping-steps">Skipping and UnSkipping Steps</h4>
 
-  <h4 id="skipping-and-unskipping-steps">Skipping and UnSkipping Steps</h4>
+    <p>Depending on the flow of the wizard, you may want to skip a step in the wizard. The component exposes two methods (<code class="clr-code">skipTab</code> and
+        <code class="clr-code">unSkipTab</code>) to skip or un-skip a step. In order to use the methods, you will have to specify a unique id as an input (
+        <code class="clr-code">clrWizardStepId</code>) and pass that value into the methods. You can also set the input <code class="clr-code">clrWizardStepIsSkipped</code> and the corresponding <code class="clr-code">clrWizardPageIsSkipped</code> to
+        skip the step and the matching page as shown in the example below.</p>
 
-  <p>Depending on the flow of the wizard, you may want to skip a step in the wizard.
-    The component exposes two methods (<code class="clr-code">skipTab</code> and
-    <code class="clr-code">unSkipTab</code>) to skip or un-skip a step. In order
-    to use the methods, you will have to specify a unique id as an input
-    (<code class="clr-code">clrWizardStepId</code>) and pass that value into the methods. You
-    can also set the input <code class="clr-code">clrWizardStepIsSkipped</code>
-    and the corresponding <code class="clr-code">clrWizardPageIsSkipped</code> to skip
-    the step and the matching page as shown in the example below.</p>
+    <h4 id="overriding-the-title-in-the-wizard-page">Overriding the Title in the Wizard Page</h4>
 
-  <h4 id="overriding-the-title-in-the-wizard-page">Overriding the Title in the Wizard Page</h4>
+    <p>By default, the page on the right-hand side will display the same title as the text that is inside the <code class="clr-code">&lt;clr-wizard-step&gt;</code>. You may wish to override this for the matching page. You can do this by including an element
+        inside the
+        <code class="clr-code">&lt;clr-wizard-page&gt;</code> with class <code class="clr-code">.wizard-page-title</code> as shown in the example below.</p>
 
-  <p>By default, the page on the right-hand side will display the same title as the text
-    that is inside the <code class="clr-code">&lt;clr-wizard-step&gt;</code>. You may wish to
-    override this for the matching page. You can do this by including an element inside the
-    <code class="clr-code">&lt;clr-wizard-page&gt;</code>
-    with class <code class="clr-code">.wizard-page-title</code> as shown in the example below.</p>
+    <clr-wizard-simple></clr-wizard-simple>
 
-  <clr-wizard-simple></clr-wizard-simple>
+    <h3 id="wizard-with-form-validation">Wizard with Form Validation</h3>
 
-  <h3 id="wizard-with-form-validation">Wizard with Form Validation</h3>
+    <p>You can use form validation with the wizard. If you wish to disable the next button until the form is valid, you can do so by setting the
+        <code class="clr-code">clrWizardPageNextDisabled</code> input of the
+        <code class="clr-code">&lt;clr-wizard-page&gt;</code> to the form’s valid property as shown in the example.</p>
 
-  <p>You can use form validation with the wizard. If you wish to disable the next button
-    until the form is valid, you can do so by setting the
-    <code class="clr-code">clrWizardPageNextDisabled</code> input of the
-    <code class="clr-code">&lt;clr-wizard-page&gt;</code> to the form’s valid property as shown
-    in the example.</p>
+    <clr-wizard-form-validation></clr-wizard-form-validation>
 
-  <clr-wizard-form-validation></clr-wizard-form-validation>
+    <h3 id="wizard-with-asynchronous-validation">Wizard with Asynchronous Validation</h3>
 
-  <h3 id="wizard-with-asynchronous-validation">Wizard with Asynchronous Validation</h3>
+    <p>You may have an asynchronous server-side call for validation. The example demonstrate how you can prevent the default behavior on clicking the next button (of going to next step) by setting the <code class="clr-code">clrWizardPagePreventDefault</code>        input to false, and programmatically calling next when the asynchronous validation call returns and passes.</p>
 
-  <p>You may have an asynchronous server-side call for validation. The example demonstrate how
-    you can prevent the default behavior on clicking the next button (of going to next step) by
-    setting the <code class="clr-code">clrWizardPagePreventDefault</code> input to false, and
-    programmatically calling next when the asynchronous validation call returns and passes.</p>
+    <clr-wizard-async-validation></clr-wizard-async-validation>
 
-  <clr-wizard-async-validation></clr-wizard-async-validation>
+    <h3 id="non-closable-wizard">Non-Closable Wizard</h3>
 
-  <h3 id="non-closable-wizard">Non-Closable Wizard</h3>
+    <p>In some circumstances, you may want to not show the closing × icon in the top right of the Wizard modal. You can remove this close × icon by setting the
+        <code class="clr-code">clrWizardClosable</code> input to <code class="clr-code">false</code>.</p>
 
-  <p>In some circumstances, you may want to not show the closing × icon in the top right
-    of the Wizard modal. You can remove this close × icon by setting the
-    <code class="clr-code">clrWizardClosable</code> input to <code class="clr-code">false</code>.</p>
+    <clr-wizard-not-closable></clr-wizard-not-closable>
 
-  <clr-wizard-not-closable></clr-wizard-not-closable>
+    <h3 id="options-for-ltclr-wizardgt">Options for &lt;clr-wizard&gt;</h3>
 
-  <h3 id="options-for-ltclr-wizardgt">Options for &lt;clr-wizard&gt;</h3>
+    <table class="table">
+        <thead>
+            <tr>
+                <th class="left">Input/Output</th>
+                <th class="hidden-xs-down">Values</th>
+                <th class="hidden-xs-down">Default</th>
+                <th class="left">Effect</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td class="left">
+                    <b>[(clrWizardOpen)]</b>
+                    <div class="hidden-sm-up">Type: Boolean</div>
+                    <div class="hidden-sm-up">Default: false</div>
+                </td>
+                <td class="hidden-xs-down">true, false</td>
+                <td class="hidden-xs-down">false</td>
+                <td class="left">
+                    Two-way binding on the state of the wizard: open or closed.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <div class="hidden-xs-down"><b>(clrWizardOpenChanged)</b></div>
+                    <div class="hidden-sm-up"><b>(clrWizard<br />OpenChanged)</b></div>
+                    <div class="hidden-sm-up">Type: Boolean</div>
+                </td>
+                <td class="hidden-xs-down">true, false</td>
+                <td class="hidden-xs-down">N/A</td>
+                <td class="left">
+                    Emits the state of the wizard when a wizard is open or closed.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <b>[clrWizardSize]</b>
+                    <div class="hidden-sm-up">Values: "md", "lg", "xl"</div>
+                    <div class="hidden-sm-up">Default: "xl"</div>
+                </td>
+                <td class="hidden-xs-down">"md", "lg", "xl"</td>
+                <td class="hidden-xs-down">"xl"</td>
+                <td class="left">Sets the size of the wizard.</td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <b>[clrWizardStepId]</b>
+                    <div class="hidden-sm-up">Values:<br />&lt;any valid id for html element&gt;</div>
+                    <div class="hidden-sm-up">Default: auto-generated</div>
+                </td>
+                <td class="hidden-xs-down">&lt;any valid id for html element&gt;</td>
+                <td class="hidden-xs-down">auto-generated</td>
+                <td class="left">
+                    Used on &lt;clr-wizard-step&gt;. If explicitly set, will assign the set id as the id for the element. If not set, the component will auto-generate the id. You can skip or unskip a step in the wizard by passing in the id to wizard's skipTab an unSkipTab
+                    methods.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <div class="hidden-xs-down"><b>[clrWizardStepIsSkipped]</b></div>
+                    <div class="hidden-sm-up"><b>[clrWizard<br />StepIsSkipped]</b></div>
+                    <div class="hidden-sm-up">Type: Boolean</div>
+                    <div class="hidden-sm-up">Default: false</div>
+                </td>
+                <td class="hidden-xs-down">true, false</td>
+                <td class="hidden-xs-down">false</td>
+                <td class="left">
+                    Used on &lt;clr-wizard-step&gt;. If true, the wizard will skip this step and not display it.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <div class="hidden-xs-down"><b>[clrWizardPageErrorFlag]</b></div>
+                    <div class="hidden-sm-up"><b>[clrWizard<br />PageErrorFlag]</b></div>
+                    <div class="hidden-sm-up">Type: Boolean</div>
+                    <div class="hidden-sm-up">Default: false</div>
+                </td>
+                <td class="hidden-xs-down">true, false</td>
+                <td class="hidden-xs-down">false</td>
+                <td class="left">
+                    Used on &lt;clr-wizard-page&gt;. If true, signifies that there was an error on the wizard page.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <div class="hidden-xs-down"><b>[clrWizardPageIsSkipped]</b></div>
+                    <div class="hidden-sm-up"><b>[clrWizard<br />PageIsSkipped]</b></div>
+                    <div class="hidden-sm-up">Type: Boolean</div>
+                    <div class="hidden-sm-up">Default: false</div>
+                </td>
+                <td class="hidden-xs-down">true, false</td>
+                <td class="hidden-xs-down">false</td>
+                <td class="left">
+                    Used on &lt;clr-wizard-page&gt;. If true, the wizard will skip this page and not display it.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <div class="hidden-xs-down"><b>[clrWizardPageNextDisabled]</b></div>
+                    <div class="hidden-sm-up"><b>[clrWizard<br />PageNext<br />Disabled]</b></div>
+                    <div class="hidden-sm-up">Type: Boolean</div>
+                    <div class="hidden-sm-up">Default: false</div>
+                </td>
+                <td class="hidden-xs-down">true, false</td>
+                <td class="hidden-xs-down">false</td>
+                <td class="left">
+                    Used on &lt;clr-wizard-page&gt;. If true, the wizard's next or finish button will be disabled.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <div class="hidden-xs-down"><b>(clrWizardPageNextDisabledChanged)</b></div>
+                    <div class="hidden-sm-up"><b>(clrWizard<br />PageNext<br />DisabledChanged)</b></div>
+                    <div class="hidden-sm-up">Type: Any</div>
+                </td>
+                <td class="hidden-xs-down">any</td>
+                <td class="hidden-xs-down">N/A</td>
+                <td class="left">
+                    Emits the state of the wizard page when the nextDisabled status changes.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <div class="hidden-xs-down"><b>(clrWizardPageOnCommit)</b></div>
+                    <div class="hidden-sm-up"><b>(clrWizardPage<br />OnCommit)</b></div>
+                    <div class="hidden-sm-up">Type: Any</div>
+                </td>
+                <td class="hidden-xs-down">any</td>
+                <td class="hidden-xs-down">N/A</td>
+                <td class="left">
+                    Emits an event when the next or finish button is clicked on the wizard page.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">
+                    <div class="hidden-xs-down"><b>(clrWizardPageOnLoad)</b></div>
+                    <div class="hidden-sm-up"><b>(clrWizard<br />PageOnLoad)</b></div>
+                    <div class="hidden-sm-up">Type: Any</div>
+                </td>
+                <td class="hidden-xs-down">any</td>
+                <td class="hidden-xs-down">N/A</td>
+                <td class="left">
+                    Emits an event when loading the wizard page.
+                </td>
+            </tr>
+            <tr>
+                <td class="left">[clrWizardClosable]</td>
+                <td>boolean</td>
+                <td>true</td>
+                <td class="left">
+                    If set to false, this will remove the closing &times; element in the top right. This means that users will need to click the Cancel button to exit the wizard without finishing.
+                </td>
+            </tr>
+        </tbody>
+    </table>
 
-  <table class="table">
-    <thead>
-    <tr>
-      <th class="left">Input/Output</th>
-      <th class="hidden-xs-down">Values</th>
-      <th class="hidden-xs-down">Default</th>
-      <th class="left">Effect</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr>
-      <td class="left">
-        <b>[(clrWizardOpen)]</b>
-        <div class="hidden-sm-up">Type: Boolean</div>
-        <div class="hidden-sm-up">Default: false</div>
-      </td>
-      <td class="hidden-xs-down">true, false</td>
-      <td class="hidden-xs-down">false</td>
-      <td class="left">
-        Two-way binding on the state of the wizard: open or closed.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <div class="hidden-xs-down"><b>(clrWizardOpenChanged)</b></div>
-        <div class="hidden-sm-up"><b>(clrWizard<br />OpenChanged)</b></div>
-        <div class="hidden-sm-up">Type: Boolean</div>
-      </td>
-      <td class="hidden-xs-down">true, false</td>
-      <td class="hidden-xs-down">N/A</td>
-      <td class="left">
-        Emits the state of the wizard when a wizard is open or closed.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <b>[clrWizardSize]</b>
-        <div class="hidden-sm-up">Values: "md", "lg", "xl"</div>
-        <div class="hidden-sm-up">Default: "xl"</div>
-      </td>
-      <td class="hidden-xs-down">"md", "lg", "xl"</td>
-      <td class="hidden-xs-down">"xl"</td>
-      <td class="left">Sets the size of the wizard.</td>
-    </tr>
-    <tr>
-      <td class="left">
-        <b>[clrWizardStepId]</b>
-        <div class="hidden-sm-up">Values:<br />&lt;any valid id for html element&gt;</div>
-        <div class="hidden-sm-up">Default: auto-generated</div>
-      </td>
-      <td class="hidden-xs-down">&lt;any valid id for html element&gt;</td>
-      <td class="hidden-xs-down">auto-generated</td>
-      <td class="left">
-        Used on &lt;clr-wizard-step&gt;. If explicitly set, will assign the
-        set id as the id for the element. If not set, the component will
-        auto-generate the id. You can skip or unskip a step in the
-        wizard by passing in the id to wizard's skipTab an unSkipTab methods.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <div class="hidden-xs-down"><b>[clrWizardStepIsSkipped]</b></div>
-        <div class="hidden-sm-up"><b>[clrWizard<br />StepIsSkipped]</b></div>
-        <div class="hidden-sm-up">Type: Boolean</div>
-        <div class="hidden-sm-up">Default: false</div>
-      </td>
-      <td class="hidden-xs-down">true, false</td>
-      <td class="hidden-xs-down">false</td>
-      <td class="left">
-        Used on &lt;clr-wizard-step&gt;. If true, the wizard will skip this
-        step and not display it.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <div class="hidden-xs-down"><b>[clrWizardPageErrorFlag]</b></div>
-        <div class="hidden-sm-up"><b>[clrWizard<br />PageErrorFlag]</b></div>
-        <div class="hidden-sm-up">Type: Boolean</div>
-        <div class="hidden-sm-up">Default: false</div>
-      </td>
-      <td class="hidden-xs-down">true, false</td>
-      <td class="hidden-xs-down">false</td>
-      <td class="left">
-        Used on &lt;clr-wizard-page&gt;. If true, signifies that there was
-        an error on the wizard page.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <div class="hidden-xs-down"><b>[clrWizardPageIsSkipped]</b></div>
-        <div class="hidden-sm-up"><b>[clrWizard<br />PageIsSkipped]</b></div>
-        <div class="hidden-sm-up">Type: Boolean</div>
-        <div class="hidden-sm-up">Default: false</div>
-      </td>
-      <td class="hidden-xs-down">true, false</td>
-      <td class="hidden-xs-down">false</td>
-      <td class="left">
-        Used on &lt;clr-wizard-page&gt;. If true, the wizard will skip this
-        page and not display it.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <div class="hidden-xs-down"><b>[clrWizardPageNextDisabled]</b></div>
-        <div class="hidden-sm-up"><b>[clrWizard<br />PageNext<br />Disabled]</b></div>
-        <div class="hidden-sm-up">Type: Boolean</div>
-        <div class="hidden-sm-up">Default: false</div>
-      </td>
-      <td class="hidden-xs-down">true, false</td>
-      <td class="hidden-xs-down">false</td>
-      <td class="left">
-        Used on &lt;clr-wizard-page&gt;. If true, the wizard's next or
-        finish button will be disabled.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <div class="hidden-xs-down"><b>(clrWizardPageNextDisabledChanged)</b></div>
-        <div class="hidden-sm-up"><b>(clrWizard<br />PageNext<br />DisabledChanged)</b></div>
-        <div class="hidden-sm-up">Type: Any</div>
-      </td>
-      <td class="hidden-xs-down">any</td>
-      <td class="hidden-xs-down">N/A</td>
-      <td class="left">
-        Emits the state of the wizard page when the nextDisabled status
-        changes.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <div class="hidden-xs-down"><b>(clrWizardPageOnCommit)</b></div>
-        <div class="hidden-sm-up"><b>(clrWizardPage<br />OnCommit)</b></div>
-        <div class="hidden-sm-up">Type: Any</div>
-      </td>
-      <td class="hidden-xs-down">any</td>
-      <td class="hidden-xs-down">N/A</td>
-      <td class="left">
-        Emits an event when the next or finish button is clicked on the
-        wizard page.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">
-        <div class="hidden-xs-down"><b>(clrWizardPageOnLoad)</b></div>
-        <div class="hidden-sm-up"><b>(clrWizard<br />PageOnLoad)</b></div>
-        <div class="hidden-sm-up">Type: Any</div>
-      </td>
-      <td class="hidden-xs-down">any</td>
-      <td class="hidden-xs-down">N/A</td>
-      <td class="left">
-        Emits an event when loading the wizard page.
-      </td>
-    </tr>
-    <tr>
-      <td class="left">[clrWizardClosable]</td>
-      <td>boolean</td>
-      <td>true</td>
-      <td class="left">
-        If set to false, this will remove the closing &times; element in the top right. This
-        means that users will need to click the Cancel button to exit the wizard without finishing.
-      </td>
-    </tr>
-    </tbody>
-  </table>
+    <h3 id="guidelines">Usage</h3>
 
-  <h3 id="guidelines">Usage</h3>
+    <p>Use a wizard to present a series of steps for completing a complex workflow, such as installation. A wizard simplifies the workflow by directing users serially through the tasks.</p>
 
-  <p>Use a wizard to present a series of steps for completing a complex workflow, such as installation. A wizard simplifies the workflow by directing users serially through the tasks.</p>
+    <p>If the user doesn’t need to complete the workflow in a predefined order, use a <a routerLink="/documentation/modals">modal</a> instead.</p>
 
-  <p>If the user doesn’t need to complete the workflow in a predefined order, use a <a href="/clarity/documentation/modals">modal</a> instead.</p>
+    <h4 id="base-wizard-size-on-use-case">Base Wizard size on use case</h4>
 
-  <h4 id="base-wizard-size-on-use-case">Base Wizard size on use case</h4>
+    <p>BSizes are 576 px, 864 px and 1056 px (default). The best design provides a good balance between white space and the number of elements per page. Overloading a page with too many controls can be a problem as can having many sparsely-populated pages.</p>
 
-  <p>BSizes are 576 px, 864 px and 1056 px (default). The best design provides a good balance between white space and the number of elements per page.   Overloading a page with too many controls can be a problem as can having  many sparsely-populated pages.</p>
+    <h4 id="title">Title</h4>
 
-  <h4 id="title">Title</h4>
+    <p>Typically task-based, the title should summarize the workflow, for example, Create Hardware Profile.</p>
 
-  <p>Typically task-based, the title should summarize the workflow, for example, Create Hardware Profile.</p>
+    <h4 id="steps">Steps</h4>
+    <div class="row buttons-modal-gfx">
+        <div class="col-md-6 col-sm-12 flex-xs-middle">
+            <img src="/assets/images/documentation/wizards/New_wizard.png" alt="Buttons on inner wizard pages" style="max-width:100%;" />
+        </div>
 
-  <h4 id="steps">Steps</h4>
-  <div class="row buttons-modal-gfx">
-    <div class="col-md-6 col-sm-12 flex-xs-middle">
-      <img src="/assets/images/documentation/wizards/New_wizard.png" alt="Buttons on inner wizard pages" style="max-width:100%;" />
+        <div class="col-md-5 offset-md-1 col-sm-12 clrweb-wizardsteps-block">
+            <h4>Streamline the number of steps</h4>
+            <p>
+                A wizard should be at least two steps. Otherwise, a modal will suffice. Also, avoid vertical scrolling of steps. At the default size, the steps scroll at 14 lines.
+            </p>
+
+            <h4>Non-branching wizards are preferable</h4>
+            <p>
+                However, if a user choice results in a change in the number of steps, make the change early in the workflow. Otherwise, users might lose track of the navigation path.
+            </p>
+
+            <h4>Steps titles should be concise and direct</h4>
+            <p>
+                To help readers scan the text, use sentence-style caps and no ending punctuation. Avoid text that is so long it wraps to the next line.
+            </p>
+        </div>
     </div>
 
-    <div class="col-md-5 offset-md-1 col-sm-12 clrweb-wizardsteps-block">
-      <h4>Streamline the number of steps</h4>
-      <p>
-        A wizard should be at least two steps.  Otherwise, a modal will suffice.  Also, avoid vertical scrolling of steps.  At the default size, the steps scroll at 14 lines.
-      </p>
+    <h4 id="pages">Pages</h4>
 
-      <h4>Non-branching wizards are preferable</h4>
-      <p>
-        However, if a user choice results in a change in the number of steps, make the change early in the workflow.  Otherwise, users might lose track of the navigation path.
-      </p>
+    <h6 id="use-the-header-to-set-context">Use the header to set context</h6>
 
-      <h4>Steps titles should be concise and direct</h4>
-      <p>
-        To help readers scan the text, use sentence-style caps and no ending punctuation. Avoid text that is so long it wraps to the next line.
-      </p>
-    </div>
-  </div>
+    <p>By default, the page header is the same text as the selected step. If needed, enhance the header text to clarify meaning.</p>
 
-  <h4 id="pages">Pages</h4>
+    <h6 id="ensure-content-is-cohesive">Ensure content is cohesive</h6>
 
-  <h6 id="use-the-header-to-set-context">Use the header to set context</h6>
+    <p>All text and components should support the goal or purpose of the page.</p>
 
-  <p>By default, the page header is the same text as the selected step.  If needed, enhance the header text to clarify meaning.</p>
+    <p>Avoid:</p>
 
-  <h6 id="ensure-content-is-cohesive">Ensure content is cohesive</h6>
+    <ul class="list">
+        <li>Putting more than one task on a page. Pages are easier to use when they present a single step of the workflow.</li>
+        <li>Opening a modal or wizard from within a wizard. This increases the complexity of the workflow.</li>
+        <li>Putting so much content on a page that it scrolls.</li>
+    </ul>
 
-  <p>All text and components should support the goal or purpose of the page.</p>
+    <h6 id="buttons-are-right-aligned-in-the-footer">Buttons are right-aligned, in the footer</h6>
 
-  <p>Avoid:</p>
+    <p>Right alignment supports the Z-pattern layout. The primary button is in the rightmost position.</p>
 
-  <ul class="list">
-    <li>Putting more than one task on a page.  Pages are easier to use when they present a single step of the workflow.</li>
-    <li>Opening a modal or wizard from within a wizard.  This increases the complexity of the workflow.</li>
-    <li>Putting so much content on a page that it scrolls.</li>
-  </ul>
+    <table class="table-noborder">
+        <tbody>
+            <tr>
+                <td class="left">First wizard page</td>
+                <td class="left">
+                    <img src="/assets/images/documentation/wizards/Wizard_buttons_1.png?1481774902655027000" width="70%" height="70%" alt="Buttons on first page of wizard" />
+                </td>
+            </tr>
+            <tr>
+                <td class="left">Inner wizard pages</td>
+                <td class="left">
+                    <img src="/assets/images/documentation/wizards/Wizard_buttons_2.png?1481774902655027000" width="70%" height="70%" alt="Buttons on wizard inner pages" />
+                </td>
+            </tr>
+            <tr>
+                <td class="left">Last page</td>
+                <td class="left">
+                    <img src="/assets/images/documentation/wizards/Wizard_buttons_3.png?1481774902655027000" width="70%" height="70%" alt="Buttons on final wizard page" />
+                </td>
+            </tr>
+        </tbody>
+    </table>
 
-  <h6 id="buttons-are-right-aligned-in-the-footer">Buttons are right-aligned, in the footer</h6>
+    <h6 id="cancel-and-close">Cancel and Close</h6>
 
-  <p>Right alignment supports the Z-pattern layout.  The primary button is in the rightmost position.</p>
+    <p>Wizards have both a Close and Cancel button. The Close button is in the upper right corner as a visual affordance and for accessibility reasons.</p>
 
-  <table class="table-noborder">
-    <tbody>
-    <tr>
-      <td class="left">First wizard page</td>
-      <td class="left">
-        <img src="/assets/images/documentation/wizards/Wizard_buttons_1.png?1481774902655027000" width="70%" height="70%" alt="Buttons on first page of wizard" />
-      </td>
-    </tr>
-    <tr>
-      <td class="left">Inner wizard pages</td>
-      <td class="left">
-        <img src="/assets/images/documentation/wizards/Wizard_buttons_2.png?1481774902655027000" width="70%" height="70%" alt="Buttons on wizard inner pages" />
-      </td>
-    </tr>
-    <tr>
-      <td class="left">Last page</td>
-      <td class="left">
-        <img src="/assets/images/documentation/wizards/Wizard_buttons_3.png?1481774902655027000" width="70%" height="70%" alt="Buttons on final wizard page" />
-      </td>
-    </tr>
-    </tbody>
-  </table>
+    <p>Clicking outside the wizard should not dismiss it. Users might accidentally click outside the wizard and lose data.</p>
 
-  <h6 id="cancel-and-close">Cancel and Close</h6>
+    <h6 id="scrolling">Scrolling</h6>
 
-  <p>Wizards have both a Close and Cancel button.  The Close button is in the upper right corner as a visual affordance and for accessibility reasons.</p>
+    <p>Some wizard pages might require scrolling. The title and buttons remain in place when the content scrolls.</p>
 
-  <p>Clicking outside the wizard should not dismiss it. Users might accidentally click outside the wizard and lose data.</p>
+    <p>Clarity does not use horizontal lines to define the scrollable area. This keeps the UI clean and simple. Also, a line above the buttons makes it appear as if all content is visible.</p>
 
-  <h6 id="scrolling">Scrolling</h6>
+    <h6 id="validation">Validation</h6>
 
-  <p>Some wizard pages might require scrolling.  The title and buttons remain in place when the content scrolls.</p>
+    <p>Validation of user input can occur at the field level, the page level, and when the user finishes the wizard. This control allows users to complete actions with minimal risk of error or data loss.</p>
 
-  <p>Clarity does not use horizontal lines to define the scrollable area.  This  keeps the UI clean and simple.  Also, a line above the buttons makes it appear as if all content is visible.</p>
-
-  <h6 id="validation">Validation</h6>
-
-  <p>Validation of user input can occur at the field level, the page level, and when the user finishes the wizard. This control allows users to complete actions with minimal risk of error or data loss.</p>
-
-  <p>For more information on validation, see <a href="/clarity/documentation/input-fields">input fields</a>.</p>
+    <p>For more information on validation, see <a routerLink="/documentation/input-fields">input fields</a>.</p>
 </article>

--- a/src/releases/0.2/0.2.10.html
+++ b/src/releases/0.2/0.2.10.html
@@ -1,0 +1,21 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Add new list styles</h6>
+        <p>Styles for <code class="clr-code">ol.list</code> ordered lists were added. A <code class="clr-code">.compact</code> classname was also added. This classname shrinks font-size and line-height of all types of lists.</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;ul class=&quot;list compact&quot;&gt;
+        ...
+    &lt;/ul&gt;
+        </code></pre>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>Fixed incorrect margin on lists inside of cards
+    </li>
+    <li bug-fix>Fixed double-margin on cards inside flexbox grid
+    </li>
+</ul>

--- a/src/releases/0.2/0.2.3.html
+++ b/src/releases/0.2/0.2.3.html
@@ -1,0 +1,7 @@
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>Website is broken in Safari
+    </li>
+    <li bug-fix>Component pages don&#39;t work in IE10 and IE11
+    </li>
+</ul>

--- a/src/releases/0.2/0.2.4.html
+++ b/src/releases/0.2/0.2.4.html
@@ -1,0 +1,62 @@
+<h2>Breaking Changes</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li breaking-change>
+        <h6>Switch over to flexbox grid in Clarity</h6>
+        <p>
+            This release moves the Clarity layout grid away from float-based columns to a flexbox style grid. There is a chance that teams using the Bootstrap grid in Clarity in nonstandard ways may see breaking changes.
+        </p>
+    </li>
+</ul>
+
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Build Clarity Seed</h6>
+        <p>
+            This is a seed project for angular 2 apps using Clarity. The goal of this project is to offer a self-contained "getting started" project for any team that wishes to build an angular 2 application using Clarity. We included the features that we think are
+            'common' for all projects, while giving room for individuals to easily extend it to fit their project's specific needs. The build system written with gulp and the npm scripts simply run the corresponding gulp commands.
+        </p>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>Login page needs spinner
+    </li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>Add table styles to Clarity UI
+    </li>
+    <li>Create basic list component for Clarity UI
+    </li>
+    <li>Implement sidenav changes
+    </li>
+    <li>Build script for bundling for production
+    </li>
+    <li>Make Clarity build on Node 6.x
+    </li>
+    <li>Bundle angular app for Clarity website
+    </li>
+    <li>Documentation for tabs
+    </li>
+    <li>Documentation for progress bars
+    </li>
+    <li>Documentation for tooltips
+    </li>
+    <li>Update the &quot;Get started&quot; documentation to include seed project
+    </li>
+    <li>Static tab demo is using &quot;#&quot; in hrefs
+    </li>
+    <li>Side navigation on components page has funky indentation
+    </li>
+    <li>The link in &quot;tabs&quot; on the website takes you to the home page
+    </li>
+    <li>Set up a loading indicator for the website component pages
+    </li>
+    <li>Move progress bars to the Clarity website
+    </li>
+    <li>Move tabs to the Clarity website
+    </li>
+</ul>

--- a/src/releases/0.2/0.2.5.html
+++ b/src/releases/0.2/0.2.5.html
@@ -1,0 +1,31 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Build Clarity Seed</h6>
+        <p>
+            This is a seed project for angular 2 apps using Clarity. The goal of this project is to offer a self-contained "getting started" project for any team
+that wishes to build an angular 2 application using Clarity. We included the features that we think are 'common' for all projects, while giving room for
+individuals to easily extend it to fit their project's specific needs. The build system written with gulp and the npm scripts simply run the corresponding gulp commands.
+        </p>
+    </li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+<li>Plan and implement packaging for Sketch components
+</li>
+<li>Create content to support templates
+</li>
+<li>Add the Sketch template to the website
+</li>
+<li>Side navigation on Components page has funky indentation
+</li>
+<li>Cards in progress bar demo are clickable to href=&quot;#&quot;
+</li>
+<li>Bundle angular app for Clarity website
+</li>
+<li>Quick changes to stackview design
+</li>
+<li>Fix error messages in seed
+</li>
+</ul>

--- a/src/releases/0.2/0.2.6.html
+++ b/src/releases/0.2/0.2.6.html
@@ -1,0 +1,53 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li new-component>
+        <h6>Stack View</h6>
+        <p>A stack view displays key/value pairs, which users can expand to show more detail. Stack views are designed for use in the main content area and modals.</p>
+    </li>
+    <li>
+        <h6>Highlight colors added to color palette</h6>
+        <p>Added a set of highlight colors to the Clarity color palette are intended for use in charts, highlighting search results, badging, and also text fields and selection.</p>
+    </li>
+</ul>
+
+<h2>Improvements</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Close dropdowns on item click</h6>
+        <p>New Angular option (clrCloseMenuOnItemClick) to close the dropdown menu when a dropdown item is clicked.</p>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>ScrollingService unit test fails
+    </li>
+    <li bug-fix>Tabs look jittery on some screens especially with longer text on the item
+    </li>
+    <li bug-fix>Typescript error in Prod Build
+    </li>
+    <li bug-fix>Make it so an item within a select box doesn't have more than one line
+    </li>
+    <li bug-fix>Fix indent on bulleted lists on website
+    </li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>Select highlight colors
+    </li>
+    <li>Standardize the way we package Clarity components
+    </li>
+    <li>Add a &quot;What&#39;s new&quot; section to the website
+    </li>
+    <li>Change the order of alerts in the demo
+    </li>
+    <li>Add the sketch template creators to the list of contributors on the website
+    </li>
+    <li>Add a &quot;loop&quot; example to the progress bar demo
+    </li>
+    <li>Add an &quot;updated&quot; signal to the left-side navigation on the website
+    </li>
+    <li>Add a quick link to &quot;components&quot; on the home page
+    </li>
+</ul>

--- a/src/releases/0.2/0.2.7.html
+++ b/src/releases/0.2/0.2.7.html
@@ -1,0 +1,25 @@
+<h2>Improvements</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Make first column of stack view sizable</h6>
+        <p>Overriding the width of the stack view's first column (labels) in CSS is now supported. Use this when the stack view is too wide or when you have an exact width of the first column.</p>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>Fixed typings error when compiling Clarity Seed for production
+    </li>
+    <li bug-fix>Rows from flexbox changes blowout some demos on clarity-demo
+    </li>
+    <li bug-fix>Put sidenav progress-bar demo back on the website
+    </li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>Add new Getting Started topics to TOC on website
+    </li>
+    <li>We need a &quot;How to file bugs&quot; section in get started on website
+    </li>
+</ul>

--- a/src/releases/0.2/0.2.8.html
+++ b/src/releases/0.2/0.2.8.html
@@ -1,0 +1,29 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Compact styling for forms</h6>
+        <p>Extends forms with a class (<code class="clr-code">form.compact</code>) that decreases space between rows on the form.</p>
+    </li>
+    <li>
+        <h6 new-component>Add code block highlighting to UI/NG components</h6>
+        <p>Adds a code block highlighting UI and Angular component (<code class="clr-code">clr-code-highlight</code>) to Clarity.</p>
+    </li>
+    <li>
+        <h6>Compact, non-bordered, and vertical HTML table styles</h6>
+        <p>0.2.8 introduced several variants of the HTML table styles in Clarity. These include a compact style (<code class="clr-code">.table-compact</code>) decreases the height of table rows from 36px to 24px, a non-bordered style (<code class="clr-code">.table-noborder</code>)
+            removes the border around HTML tables and in between rows (except for below the header), and a vertical style (<code class="clr-code">.table-vertical</code>) that displays an HTML table with the same orientation as the key-value layout of
+            a Stack View. While not documented on the website yet, examples are available on the Clarity demos in the git repo.</p>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>Tabs angular component does not render correctly in IE10
+    </li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>Make table font-size match stack-view font size
+    </li>
+</ul>

--- a/src/releases/0.2/0.2.9.html
+++ b/src/releases/0.2/0.2.9.html
@@ -1,0 +1,27 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Expose a close event in the alert angular component</h6>
+        <p>Allows developers to bind callbacks to the alert close event in their templates as in the following example:</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;clr-alert [clrAlertType]=&quot;&apos;alert-success&apos;&quot; (clrAlertClosedChange)=&quot;yourMethod()&quot;&gt;
+         &hellip;...&hellip;
+    &lt;/clr-alert&gt;
+        </code></pre>
+    </li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>Implement new &quot;available components&quot; page design for website
+    </li>
+    <li>Add code highlight to table demos
+    </li>
+    <li>Fix the width of the &quot;what&#39;s new&quot; page on the website
+    </li>
+    <li>Improve the &quot;available components&quot; table in the &quot;components&quot; page on the website
+    </li>
+    <li>Add analytics to website
+    </li>
+</ul>

--- a/src/releases/0.3/0.3.0.html
+++ b/src/releases/0.3/0.3.0.html
@@ -1,0 +1,323 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Simpler imports</h6>
+        <p>Now you can import all of our components from clarity-angular:</p>
+
+        <pre class=" language-js"><code class=" language-js">
+    import {{ '{' }} DROPDOWN_DIRECTIVES {{ '}' }} from 'clarity-angular';
+    import {{ '{' }} Modal {{ '}' }} from 'clarity-angular';
+    ...
+        </code></pre>
+        <p>If you are using system.js, you also need to add the package config for the above import statements to work:
+        </p>
+        <pre class=" language-js"><code class=" language-js">
+    System.config({{ '{' }}
+      packages: {{ '{' }}
+          'clarity-angular' : {{ '{' }} main: 'index.js', defaultExtension: 'js' {{ '}' }},
+          ...
+      {{ '}' }},
+      ...
+    {{ '}' }});
+        </code></pre>
+
+    </li>
+    <li>
+        <h6>Upgrade to Angular 2 RC4</h6>
+        <p>Using <a href="https://angular.io/docs/ts/latest/guide/animations.html" target="_blank">Angular's new animation system</a> in Modal and Stackview.</p>
+    </li>
+
+    <li>
+        <h6>Taking actions on alerts</h6>
+        <p>Alerts can now support alert actions. Actions can be dropdowns or links.</p>
+        <p>Dropdowns as alert actions:</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;div class=&quot;alert alert-danger&quot;&gt;
+        &lt;div class=&quot;alert-item&quot;&gt;
+            &lt;span&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;/span&gt;
+            &lt;div class=&quot;alert-actions&quot;&gt;
+                &lt;div class=&quot;alert-action dropdown bottom-right&quot;&gt;
+                    &lt;a class=&quot;dropdown-toggle&quot;&gt;Actions&lt;/a&gt;
+                    &lt;div class=&quot;dropdown-menu&quot;&gt;
+                        &lt;a class=&quot;dropdown-item&quot; href=&quot;javascript://&quot;&gt;Shutdown&lt;/a&gt;
+                        &lt;a class=&quot;dropdown-item&quot; href=&quot;javascript://&quot;&gt;Suspend&lt;/a&gt;
+                        &lt;a class=&quot;dropdown-item&quot; href=&quot;javascript://&quot;&gt;Reboot&lt;/a&gt;
+                        &lt;a class=&quot;dropdown-item&quot; href=&quot;javascript://&quot;&gt;Delete&lt;/a&gt;
+                    &lt;/div&gt;
+                &lt;/div&gt;
+            &lt;/div&gt;
+        &lt;/div&gt;
+    &lt;/div&gt;
+        </code></pre>
+
+        <p>Links as alert actions:</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;div class=&quot;alert alert-info&quot;&gt;
+        &lt;button type=&quot;button&quot; class=&quot;close&quot; aria-label=&quot;Close&quot;&gt;
+            &lt;span aria-hidden=&quot;true&quot;&gt;&times;&lt;/span&gt;
+        &lt;/button&gt;
+        &lt;div class=&quot;alert-item&quot;&gt;
+            &lt;span class=&quot;alert-text&quot;&gt;
+                ...
+            &lt;/span&gt;
+            &lt;div class=&quot;alert-actions&quot;&gt;
+                &lt;a href=&quot;javascript://&quot; class=&quot;alert-action&quot;&gt;Acknowledge&lt;/a&gt;
+                &lt;a href=&quot;javascript://&quot; class=&quot;alert-action&quot;&gt;Reset to green&lt;/a&gt;
+            &lt;/div&gt;
+        &lt;/div&gt;
+    &lt;/div&gt;
+        </code></pre>
+    </li>
+
+    <li>
+        <h6>Inverse Spinners</h6>
+        <p>Use the <code class="clr-code">.spinner-inverse</code> class to generate spinners for dark backgrounds:</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;span class=&quot;spinner spinner-inverse&quot;&gt;
+        Loading...
+    &lt;/span&gt;
+        </code></pre>
+    </li>
+</ul>
+
+<h2>Breaking Changes</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li breaking-change>
+        <h6>Angular RC4</h6>
+        <p>In order to use Clarity 0.3.0 components, your web application must also be on Angular version RC4. Here are sample version numbers you could use in your <code class="clr-code">package.json</code>:</p>
+
+        <pre class=" language-js"><code class=" language-js">
+    "dependencies": {{ '{' }}
+        "@angular/common": "2.0.0-rc.4",
+        "@angular/compiler": "2.0.0-rc.4",
+        "@angular/core": "2.0.0-rc.4",
+        "@angular/http": "2.0.0-rc.4",
+        "@angular/platform-browser": "2.0.0-rc.4",
+        "@angular/platform-browser-dynamic": "2.0.0-rc.4",
+        "@angular/router": "3.0.0-beta.1",
+        "@angular/upgrade": "2.0.0-rc.4",
+        ...
+    {{ '}' }}
+        </code></pre>
+
+        <p>Refer to <a href="https://github.com/angular/angular/blob/master/CHANGELOG.md" target="_blank">Angular's changelog</a> for a complete list of breaking changes that may impact your application.</p>
+    </li>
+
+    <li breaking-change>
+        <h6>Modal and Stack View</h6>
+        <p>Because Angular animations are built on top of the <a href="https://w3c.github.io/web-animations/" target="_blank">Web Animations API</a>, your application must include <code class="clr-code">web-animations.min.js</code> polyfill for the animation
+            to work on browsers that do not support it. You can add the polyfill by installing it on your app...</p>
+
+        <pre class=" language-js"><code class=" language-js">
+    "dependencies": {{ '{' }}
+        ...
+        "web-animations-js": "^2.2.1",
+        ...
+    {{ '}' }}
+        </code></pre>
+
+        <p>...and including it in your application. A sample dev version of your <code class="clr-code">index.html</code> might include something like:</p>
+
+        <pre class=" language-html"><code class="language-html">
+            &lt;script src=&quot;node_modules/web-animations-js/web-animations.min.js&quot;&gt;&lt;/script&gt;
+        </code></pre>
+    </li>
+
+    <li breaking-change>
+        <h6>Form Validation</h6>
+        <p>The markup for validating forms has changed from...</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;div class=&quot;validated-input invalid&quot;&gt;
+       &lt;input type=&quot;text&quot; style=&quot;width:300px&quot;/&gt;
+       &lt;div aria-hidden=&quot;true&quot; class=&quot;tooltip tooltip-md&quot;&gt;This field is required.&lt;/div&gt;
+    &lt;/div&gt;
+        </code></pre>
+
+        <p>...to...</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;div class=&quot;tooltip tooltip-validation invalid&quot;&gt;
+        &lt;input type=&quot;text&quot; style=&quot;width:300px&quot;/&gt;
+        &lt;span class=&quot;tooltip-content&quot;&gt;This field is required.&lt;/span&gt;
+    &lt;/div&gt;
+        </code></pre>
+    </li>
+
+    <li breaking-change>
+        <h6>Login Form Refactor</h6>
+        <p>Login forms now have to be wrapped with a <code class="clr-code">.login-wrapper</code>. This was done to support login backgrounds and fix an IE 10/11 vertical alignment issue.</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;div class=&quot;login-wrapper&quot;&gt;
+        &lt;div class=&quot;login&quot;&gt;
+            ...
+        &lt;/div&gt;
+    &lt;/div&gt;
+        </code></pre>
+    </li>
+
+    <li breaking-change>
+        <h6>Login Validation Refactor</h6>
+        <p>The login form validation markup has changed from...</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;div class=&quot;error active&quot;&gt;
+        &lt;span class=&quot;alert-icon icon-danger-white&quot;&gt;&lt;/span&gt;
+        Invalid user name or password
+    &lt;/div&gt;
+        </code></pre>
+
+        <p>...to...</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;div class=&quot;error active&quot;&gt;
+        Invalid user name or password
+    &lt;/div&gt;
+        </code></pre>
+
+        <p>The need to explicitly use the icon markup was removed.</p>
+    </li>
+
+    <li breaking-change>
+        <h6>Layout Refactor</h6>
+        <p>Clarity layout has changed from...</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;div class=&quot;main-nav&quot;&gt;
+        &lt;header class=&quot;header&quot;&gt;&lt;/header&gt;
+        &lt;nav class=&quot;sub-nav&quot;&gt;&lt;/nav&gt;
+    &lt;/div&gt;
+    &lt;div class=&quot;main-container&quot;&gt;
+        &lt;div class=&quot;content-area&quot;&gt;&lt;/div&gt;
+        &lt;div class=&quot;side-nav&quot;&gt;&lt;/div&gt;
+    &lt;/div&gt;
+        </code></pre>
+
+        <p>...to...</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;div class=&quot;main-container&quot;&gt;
+        &lt;header class=&quot;header&quot;&gt;&lt;/header&gt;
+        &lt;nav class=&quot;sub-nav&quot;&gt;&lt;/nav&gt;
+        &lt;div class=&quot;content-container&quot;&gt;
+            &lt;div class=&quot;content-area&quot;&gt;&lt;/div&gt;
+            &lt;div class=&quot;side-nav&quot;&gt;&lt;/div&gt;
+        &lt;/div&gt;
+    &lt;/div&gt;
+        </code></pre>
+
+        <p>This refactor gives us the ability to add other elements like app level alerts or footers to the <code class="clr-code">.main-container</code> which is now a vertical flexbox. Additional sections can also be added to the <code class="clr-code">.content-container</code>            (a horizontal flexbox) which contains the <code class="clr-code">.sidenav</code> and the <code class="clr-code">.content-area</code> after this change.</p>
+    </li>
+
+    <li breaking-change>
+        <h6>Alerts</h6>
+        <p>Alert markup has changed from...</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;div class=&quot;alert alert-danger alert-sm&quot;&gt;
+        &lt;div class=&quot;alert-item&quot;&gt;
+            &lt;span class=&quot;alert-icon icon-danger&quot;&gt;&lt;/span&gt;
+            &lt;span class=&quot;alert-text&quot;&gt;Alert in a card.&lt;/span&gt;
+        &lt;/div&gt;
+        &lt;button type=&quot;button&quot; class=&quot;close&quot; aria-label=&quot;Close&quot;&gt;
+            &lt;span aria-hidden=&quot;true&quot;&gt;&amp;times;&lt;/span&gt;
+        &lt;/button&gt;
+    &lt;/div&gt;
+        </code></pre>
+
+        <p>...to...</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;div class=&quot;alert alert-danger alert-sm&quot;&gt;
+        &lt;button type=&quot;button&quot; class=&quot;close&quot; aria-label=&quot;Close&quot;&gt;
+            &lt;span aria-hidden=&quot;true&quot;&gt;&amp;times;&lt;/span&gt;
+        &lt;/button&gt;
+        &lt;div class=&quot;alert-item&quot;&gt;
+            &lt;span&gt;Alert in a card.&lt;/span&gt;
+        &lt;/div&gt;
+    &lt;/div&gt;
+        </code></pre>
+
+        <p>Changes:</p>
+        <ol class="list">
+            <li>Move the <code class="clr-code">.close</code> button on the top before the <code class="clr-code">.alert-item</code></li>
+            <li>Remove the <code class="clr-code">.alert-icon</code> markup from <code class="clr-code">.alert-item</code></li>
+        </ol>
+    </li>
+
+    <li breaking-change>
+        <h6>Header</h6>
+        <p>Header branding area markup has change from...</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;div class=&quot;branding&quot;&gt;
+        &lt;a&gt;&lt;img src=&quot;img/vmw-logo.svg&quot; class=&quot;logo&quot;&gt;&lt;/a&gt;
+        &lt;span class=&quot;title&quot;&gt;Clarity Demo&lt;/span&gt;
+    &lt;/div&gt;
+        </code></pre>
+
+        <p>...to...</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;div class=&quot;branding&quot;&gt;
+        &lt;a href=&quot;#&quot;&gt;
+            &lt;span class=&quot;clr-icon clr-vmw-logo&quot;&gt;&lt;/span&gt;
+            &lt;span class=&quot;title&quot;&gt;Clarity Demo&lt;/span&gt;
+        &lt;/a&gt;
+    &lt;/div&gt;
+        </code></pre>
+
+        <p>Header Search markup has changed from...</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;div class=&quot;search-box&quot;&gt;
+        &lt;span class=&quot;nav-icon fa fa-search&quot;&gt;&lt;/span&gt;
+        &lt;input type=&quot;text&quot; placeholder=&quot;Search for VMs...&quot;&gt;
+    &lt;/div&gt;
+        </code></pre>
+
+        <p>...to...</p>
+
+        <pre class=" language-html"><code class=" language-html">
+    &lt;form class=&quot;search-box&quot;&gt;
+        &lt;span class=&quot;nav-icon fa fa-search&quot;&gt;&lt;/span&gt;
+        &lt;input type=&quot;text&quot; placeholder=&quot;Search for VMs...&quot;&gt;
+    &lt;/form&gt;
+        </code></pre>
+    </li>
+</ul>
+
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>Fix master build&#39;s warning message
+    </li>
+    <li bug-fix>Update the Clarity grid rows with the correct margins
+    </li>
+    <li bug-fix>Multiple scroll bars appear when screen is resized in the new layout
+    </li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>Update typography documentation
+    </li>
+    <li>Icons - Implementation: HTML/CSS
+    </li>
+    <li>Define default illustration for the background of the login form
+    </li>
+    <li>Finalize the list component
+    </li>
+    <li>Support product logo as a div/span svg background
+    </li>
+    <li>Implement the popover/tooltip component
+    </li>
+    <li>Update clarity seed to use 0.3.0
+    </li>
+    <li>Update build info (CONTRIBUTING.md, peer dependency versions, etc) to current
+    </li>
+</ul>

--- a/src/releases/0.3/0.3.1.html
+++ b/src/releases/0.3/0.3.1.html
@@ -1,0 +1,82 @@
+<h2>
+    Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Static progress bar</h6>
+        <p>Static progress bars are progress bars that do not animate when they are drawn in the DOM. This allows them to be used inside of Kendo UI data grids and other components that redraw themselves at set intervals.</p>
+        <p>Because IE/Edge offered no way to override the default animation of HTML5 progress elements, a new component had to be created. This component consists of a <code class="clr-code">.progress-static</code> container with a <code class="clr-code">.progress-meter</code>            element inside of it.</p>
+        <p>The <code class="clr-code">.progress-meter</code> component has to use a <code class="clr-code">data-value</code> attribute instead of a <code class="clr-code">value</code> attribute. Other than that it works exactly the same as the existing progress
+            bar component.</p>
+
+        <p>Existing progress bar HTML...</p>
+        <pre class="language-html"><code class="language-html">
+    &lt;div class=&quot;progress-static&quot;&gt;
+        &lt;div class=&quot;progress-meter&quot; data-value=&quot;16&quot;&gt;&lt;/div&gt;
+    &lt;/div&gt;
+      </code></pre>
+        <p>Static progress bar HTML...</p>
+        <pre class="language-html"><code class="language-html">
+    &lt;div class=&quot;progress demo&quot;&gt;
+        &lt;progress max=&quot;100&quot; value=&quot;16&quot; data-displayval=&quot;16%&quot;&gt;&lt;/progress&gt;
+    &lt;/div&gt;
+      </code></pre>
+    </li>
+    <li>
+        <h6>Inline progress bars (Progress Blocks and Groups)</h6>
+        <ul class="list">
+            <li>A <code class="clr-code">.progress-block</code> component was added to the progress-bar which allows the use of <code class="clr-code">label</code>s and <code class="clr-code">span</code>s to share horizontal space with the progress bar.</li>
+            <li>A <code class="clr-code">.progress-group</code> component was added to the progress-bar to enable content above and below a progress bar as well as allowing for stacked progress bars.</li>
+            <li><code class="clr-code">.progress-block</code> and <code class="clr-code">.progress-group</code> can be combined and both work inside of cards.</li>
+        </ul>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>
+        Links in header nav are getting underlines on them
+    </li>
+    <li bug-fix>
+        Clarity header logo jumps up when there is no title next to it
+    </li>
+    <li bug-fix>
+        Clarity website 404s no longer directing to the error page
+    </li>
+    <li bug-fix>
+        Re-add support for css animation
+    </li>
+    <li bug-fix>
+        Implement the new changes to tabs based on the new design spec
+    </li>
+    <li bug-fix>
+        Fix Checkbox jitter issue in Safari
+    </li>
+    <li bug-fix>
+        Fix margins of components used in a grid
+    </li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>
+        Clean up tests to not use the deprecated jasmine functions inside @angular/core/testing
+    </li>
+    <li>
+        Precompile components for router
+    </li>
+    <li>
+        Add note to login doc about background color/image
+    </li>
+    <li>
+        Add content to the web site to support the new table style
+    </li>
+    <li>
+        Create documentation for lists
+    </li>
+    <li>
+        Improve the documentation of input fields to include documenting input validation
+    </li>
+    <li>
+        Add code coverage (Istanbul) to seed
+    </li>
+</ul>

--- a/src/releases/0.3/0.3.2.html
+++ b/src/releases/0.3/0.3.2.html
@@ -1,0 +1,56 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>App Level Alerts</h6>
+        <p>An app-level alert appears at the top of the screen, above the application header. This alert is reserved for a system-level message.</p>
+        <pre class="language-html"><code class="language-html">
+    &lt;div class=&quot;alert alert-app-level alert-danger&quot;&gt;
+        &lt;button type=&quot;button&quot; class=&quot;close&quot; aria-label=&quot;Close&quot;&gt;
+            &lt;span aria-hidden=&quot;true&quot;&gt;&amp;times;&lt;/span&gt;
+        &lt;/button&gt;
+        &lt;div class=&quot;alert-item&quot;&gt;
+            &lt;div class=&quot;alert-text&quot;&gt;
+                Alert Type: Danger
+            &lt;/div&gt;
+            &lt;div class=&quot;alert-actions&quot;&gt;
+                &lt;button class=&quot;btn alert-action&quot;&gt;Action&lt;/button&gt;
+            &lt;/div&gt;
+        &lt;/div&gt;
+    &lt;/div&gt;
+        </code></pre>
+    </li>
+    <li>
+        <h6>Inverse Buttons, update outline buttons and add min and max widths to buttons</h6>
+        <p>Inverse buttons can be used on dark backgrounds</p>
+        <pre class="language-html"><code class="language-html">
+    &lt;button type=&quot;submit&quot; class=&quot;btn btn-inverse&quot;&gt;Inverse&lt;/button&gt;
+        </code></pre>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>
+        The closing &quot;x&quot; in an alert seems vertically mis-aligned
+    </li>
+    <li bug-fix> Stackviews do not render correctly on IE
+    </li>
+    <li bug-fix> Buttons alignment bug fix
+    </li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>
+        Improve sass compilation watch
+    </li>
+    <li>
+        Clean up gulpfile.js
+    </li>
+    <li>
+        Create variables for common Clarity height/width values
+    </li>
+    <li>
+        Create a landing page for Clarity Demos
+    </li>
+</ul>

--- a/src/releases/0.3/0.3.3.html
+++ b/src/releases/0.3/0.3.3.html
@@ -1,0 +1,28 @@
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>
+        Header bug - Divider disappears when screen is resized
+    </li>
+    <li bug-fix>
+        Fix grid row negative right margin
+    </li>
+    <li bug-fix>
+        Clicking on the error icon in an input field should display the error
+    </li>
+    <li bug-fix>
+        [Seed] Fix karma to exit properly
+    </li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>
+        Fix alert demos to show alert icons
+    </li>
+    <li>
+        Create a landing page for Clarity
+    </li>
+    <li>
+        Move UI grid to the website
+    </li>
+</ul>

--- a/src/releases/0.3/0.3.4.html
+++ b/src/releases/0.3/0.3.4.html
@@ -1,0 +1,37 @@
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>
+        Form field bottom border inching up
+    </li>
+    <li bug-fix>
+        Card group doesn&#39;t wrap in IE 10
+    </li>
+    <li bug-fix>
+        In seed, e2e test is throwing error when using gulp
+    </li>
+    <li bug-fix>
+        Checkboxes and radios with empty labels lose alignment in forms
+    </li>
+    <li bug-fix>
+        Clarity icon fix
+    </li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>
+        Design for blocking user input while spinner is visible
+    </li>
+    <li>
+        Remove research tab from component pages
+    </li>
+    <li>
+        Use Clarity dropdowns for the cards overflow menu
+    </li>
+    <li>
+        Restyle example text string used beneath input lines in forms
+    </li>
+    <li>
+        Remove hover effect on flat buttons
+    </li>
+</ul>

--- a/src/releases/0.3/0.3.5.html
+++ b/src/releases/0.3/0.3.5.html
@@ -1,0 +1,48 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Build optimization</h6>
+        <p>Improves Clarity build, reducing build time by 80-90%. Also fixes a SASS/SCSS issue that was preventing Clarity build script from running on Windows. </p>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>
+        App Level Alert is not vertically aligned when alert action is not present
+    </li>
+    <li bug-fix>
+        Fix build issues on windows machine
+    </li>
+    <li bug-fix>
+        Header sub areas should have a constant height
+    </li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>
+        Document the &quot;Application Structure and Layout&quot;
+    </li>
+    <li>
+        Create Documentation for Grids
+    </li>
+    <li>
+        Add event-stream to package.json
+    </li>
+    <li>
+        Update Alert Icons
+    </li>
+    <li>
+        Move application structure and layout to the website
+    </li>
+    <li>
+        Stack View Editor: Design indicator that a value has been changed
+    </li>
+    <li>
+        Document Navigation Structure
+    </li>
+    <li>
+        Stack View Editor: Style the remove &quot;X&quot;
+    </li>
+</ul>

--- a/src/releases/0.3/0.3.6.html
+++ b/src/releases/0.3/0.3.6.html
@@ -1,0 +1,6 @@
+<h2>Changes</h2>
+<ul class="list-unstyled">
+    <li>
+        Dropdowns Refactor - Add classes on the host element instead of nesting them
+    </li>
+</ul>

--- a/src/releases/0.4/0.4.0.html
+++ b/src/releases/0.4/0.4.0.html
@@ -1,0 +1,80 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Add SASS mixin to target problematic browsers</h6>
+        <p>
+            The <code class="clr-code">fixForFirefox</code>, <code class="clr-code">fixForMsEdge</code>,
+            <code class="clr-code">fixForIE10AndUp</code>, and <code class="clr-code">fixForIE11AndUp</code> SASS mixins were added to <code class="clr-code">clarity/utils/helpers.clarity.scss</code>. These mixins allow us to target CSS fixes to specific
+            browsers.
+        </p>
+    </li>
+</ul>
+
+<h2>Breaking Changes</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li breaking-change>
+        <h6>Update Clarity to use BS4 alpha 3</h6>
+        <p>
+            Clarity has been upgraded to use BS4 Alpha 3. This allows users of Clarity to take advantage of the new BS for functionality with the flex box grid. With Alpha 3, BS4 rewrote some of the classnames related to their grid. Users of Clarity who were using
+            Push, pull, offset classes May need to replace the old class names with the new format. More information is available in the
+            <a href="http://v4-alpha.getbootstrap.com/layout/grid/#example-offsetting-columns" target="_blank">BS4 documentation</a>.
+        </p>
+    </li>
+    <li breaking-change>
+        <h6>Cleanup baselineRem() and rpx() SASS function calls</h6>
+        <p>
+            The <code class="clr-code">rpx()</code> SASS function has been removed from Clarity. Make sure to replace it with a measurement in pixels. For example, <code class="clr-code">padding-top: rpx(2)</code> would become <code class="clr-code">padding-top: 2px</code>.
+        </p>
+    </li>
+    <li breaking-change>
+        <h6>Typography updates - Implementation: HTML/CSS</h6>
+        <p>
+            Clarity's typography has been completely redone. It is imperative that all applications upgrading to 0.4.0 verify any customizations they had previously made to Clarity's font specs. Our own internal upgrades involved minimal changes to existing CSS overrides.
+            Nevertheless, Clarity strongly advises all users to visually check their applications after upgrading.
+        </p>
+        <p>
+            More information on SASS/SCSS convenience functions that have been added to Clarity to assist with the use of typography can be found in the typography documentation.
+        </p>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>
+        Vertical alignment issue with the labels in Firefox
+    </li>
+    <li bug-fix>
+        Row arrow alignment issue with stack views in Firefox and IE
+    </li>
+    <li bug-fix>
+        Toggle switch alignment issue in Firefox and MSEdge
+    </li>
+    <li bug-fix>
+        Vertical alignment issue with buttons in IE (not Edge)
+    </li>
+    <li bug-fix>
+        Fixed a padding issue with text fields in IE10
+    </li>
+    <li bug-fix>
+        Hex code display in color contrast demo is not visible in IE10
+    </li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>
+        Add TSLint to Clarity
+    </li>
+    <li>
+        Optimize base64 Clarity fonts
+    </li>
+    <li>
+        Address additional cases for tabs including multi-level, scrolling, and usage in different areas like wizards and modals
+    </li>
+    <li>
+        Dropdowns Refactor - Add classes on the host element instead of nesting them
+    </li>
+    <li>
+        Upgrade website to 0.4.0
+    </li>
+</ul>

--- a/src/releases/0.4/0.4.1.html
+++ b/src/releases/0.4/0.4.1.html
@@ -1,0 +1,112 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Add a medium spinner size</h6>
+        <p>Clarity Spinners now support 3 sizes:</p>
+        <ul>
+            <li><code class="clr-code">.spinner-sm</code></li>
+            <li><code class="clr-code">.spinner-md</code></li>
+            <li><code class="clr-code">.spinner-lg</code></li>
+        </ul>
+        <p><code class="clr-code">.spinner-inline</code> is always a small sized spinner and can be used with text.</p>
+    </li>
+    <li>
+        <h6>Allow forms to use a grid layout</h6>
+        <p>
+            Clarity Forms can now be used within Grids by extending the <code class="clr-code">.row</code> class on a <code class="clr-code">.form-group</code> and wrapping the form fields in column classes.
+        </p>
+    </li>
+    <li>
+        <h6>Add inputs/outputs to tabs and remove unnecessary wrapper elements</h6>
+        <p>
+            While the markup hasn't changed for the tabs, the final rendered HTML looks a bit different with this release. Most notable changes are:
+        </p>
+
+        <ul class="list" style="list-style: disc; margin-top: 24px">
+            <li>
+                Moved most of the attributes to <code class="clr-code">&lt;clr-tab-link&gt;&lt;/clr-tab-link&gt;</code> and <code class="clr-code">&lt;clr-tab-content&gt;&lt;/clr-tab-content&gt;</code> tags from their children.
+            </li>
+            <li>
+                <code class="clr-code">.active</code> class applied to the active <code class="clr-code">&lt;clr-tab-link&gt;&lt;/clr-tab-link&gt;</code> and <code class="clr-code">&lt;clr-tab-content&gt;&lt;/clr-tab-content&gt;</code> tags.
+            </li>
+            <li>
+                Ability to assign custom id's to <code class="clr-code">&lt;clr-tab-link&gt;&lt;/clr-tab-link&gt;</code> and <code class="clr-code">&lt;clr-tab-content&gt;&lt;/clr-tab-content&gt;</code> tags
+            </li>
+            <li>
+                Removed <code class="clr-code">&lt;li&gt;&lt;/li&gt;</code> tags in the tab links
+            </li>
+        </ul>
+        <div style="margin-top: 24px">
+            This is a simplified version of what the markup renders to in the browser:
+            <h6>Until 0.4.0:</h6>
+            <pre>
+    <code class="language-html">
+        &lt;clr-tabs&gt;
+            &lt;ul class=&quot;nav&quot; role=&quot;tablist&quot;&gt;
+                &lt;clr-tab-link&gt;
+                    &lt;li class=&quot;nav-item&quot; role=&quot;presentation&quot;&gt;
+                    &lt;a class=&quot;nav-link active&quot; href=&quot;#&quot;
+                        role=&quot;tab&quot; id=&quot;clr-tabs-0-tab-0&quot;
+                        aria-selected=&quot;true&quot; aria-controls=&quot;clr-tabs-0-content-0&quot;&gt;
+                        ...
+                    &lt;/a&gt;
+                    &lt;/li&gt;
+                &lt;/clr-tab-link&gt;
+                ...
+            &lt;/ul&gt;
+            &lt;clr-tab-content&gt;
+                &lt;section role=&quot;tabpanel&quot; id=&quot;clr-tabs-0-content-0&quot; aria-hidden=&quot;false&quot; aria-labelledby=&quot;clr-tabs-0-tab-0&quot;&gt;
+                ...
+                &lt;/section&gt;
+            &lt;/clr-tab-content&gt;
+            ...
+        &lt;/clr-tabs&gt;
+</code></pre>
+            <h6>In 0.4.1:</h6>
+            <pre>
+    <code class="language-html">
+        &lt;clr-tabs&gt;
+            &lt;ul class=&quot;nav&quot; role=&quot;tablist&quot;&gt;
+                &lt;clr-tab-link class=&quot;nav-item
+                active&quot; role=&quot;presentation&quot;
+                id=&quot;link1&quot; aria-selected=&quot;true&quot;
+                aria-controls=&quot;content1&quot;&gt;
+                    &lt;a class=&quot;nav-link&quot; href=&quot;#&quot; role=&quot;tab&quot;&gt;
+                    ...
+                    &lt;/a&gt;
+                &lt;/clr-tab-link&gt;
+            &lt;/ul&gt;
+            &lt;clr-tab-content role=&quot;tabpanel&quot;
+                id=&quot;content1&quot; aria-hidden=&quot;false&quot;
+                aria-labelledby=&quot;link1&quot;
+                data-hidden=&quot;false&quot;
+                class=&quot;active&quot;&gt;
+                &lt;section&gt;
+                ...
+                &lt;/section&gt;
+            &lt;/clr-tab-content&gt;
+        &lt;/clr-tabs&gt;
+</code></pre>
+        </div>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>
+        Refactor toggles to use baselineRem and fix vertical alignment issues
+    </li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>
+        Upgrade to BS4 Alpha 4
+    </li>
+    <li>
+        Add grid flex items vertical and horizontal alignment demos to the website
+    </li>
+    <li>
+        Revisit color for selected state
+    </li>
+</ul>

--- a/src/releases/0.4/0.4.2.html
+++ b/src/releases/0.4/0.4.2.html
@@ -1,0 +1,42 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Implement alternative for outline:none</h6>
+        <div class="alert alert-warning">
+            <div class="alert-item">
+                <span class="alert-text">
+                  While this is not a breaking change, product teams that do not
+                  want accessible outlines in their applications should review
+                  any impact this change had to determine if they want to override
+                  the outline style on their own.
+              </span>
+            </div>
+        </div>
+        <p style="margin-top: 12px">
+            The Clarity team implemented accessible outline highlighting for keyboard navigation. Previously, Clarity UI had overridden the default. There may be an impact for applications that had relied on the default override. In those cases, developers should
+            implement their own override. The Clarity team removed the override because it hindered accessibility.
+        </p>
+    </li>
+    <li>
+        <h6>Update visited links color</h6>
+        <p>
+            The visited link text color has been changed. Just a heads up that there's a slightly different shade of purple in use. Those who were already overriding the visited link text color should not be impacted.
+        </p>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>
+        Text color on clickable cards changes when wrapped in anchor tag
+    </li>
+    <li bug-fix>
+        Fix Inline Spinners Alignment
+    </li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>Revisit Clarity Color Usage</li>
+    <li>Refactor buttons code</li>
+</ul>

--- a/src/releases/0.4/0.4.3.html
+++ b/src/releases/0.4/0.4.3.html
@@ -1,0 +1,6 @@
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>
+        Add font-family declaration to body tag
+    </li>
+</ul>

--- a/src/releases/0.5/0.5.0.html
+++ b/src/releases/0.5/0.5.0.html
@@ -1,0 +1,79 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Upgrade Clarity Seed to Angular 2.0.0</h6>
+        <h6>Upgrade Clarity to Angular 2.0.0</h6>
+        <p style="margin-top: 24px">
+            Clarity 0.5.0 is in Angular 2.0.0 Final!
+        </p>
+        <p>
+            Here are the recommended version numbers you could use in your package.json:
+        </p>
+        <pre>
+    <code class="language-js">
+    "dependencies": {{ '{' }}
+        "@angular/common": "2.0.0",
+        "@angular/compiler": "2.0.0",
+        "@angular/core": "2.0.0",
+        "@angular/forms": "2.0.0",
+        "@angular/http": "2.0.0",
+        "@angular/platform-browser": "2.0.0",
+        "@angular/platform-browser-dynamic": "2.0.0",
+        "@angular/router": "3.0.0",
+        "@angular/upgrade": "2.0.0",
+        ...
+    {{ '}' }}
+</code></pre>
+        <p>
+            Declaring directives and pipes in components has been deprecated. That means you will no longer import Clarity directives in the components as you have done with previous versions like this:
+        </p>
+        <pre>
+    <code class="language-js">
+    import {{ '{' }}SOME_CLARITY_DIRECTIVE{{ '}' }} from "clarity-angular";
+    @Component({{ '{' }}
+        ...
+        directives: [SOME_CLARITY_DIRECTIVE],
+        ...
+    {{ '}' }});
+
+    export class YourComponent {{ '{' }}        {{ '}' }}
+</code></pre>
+
+        <p>
+            Instead, now an application that consumes Clarity should at least have one app-level module like below:
+        </p>
+
+        <pre>
+    <code class="language-js">
+    import {{ '{' }} NgModule {{ '}' }} from '@angular/core';
+    import {{ '{' }} BrowserModule {{ '}' }} from '@angular/platform-browser';
+    import {{ '{' }} ClarityModule {{ '}' }} from 'clarity-angular';
+    import {{ '{' }} AppComponent {{ '}' }} from './app.component';
+
+    @NgModule({{ '{' }}
+        imports: [
+            BrowserModule,
+            ClarityModule,
+            ....(other modules from Angular or 3rd parties for your app)
+        ],
+        declarations: [ AppComponent ],
+        bootstrap: [ AppComponent ]
+    {{ '}' }})
+
+    export class AppModule {{ '{' }}
+    {{ '}' }}
+</code></pre>
+
+        <p>
+            Your dependencies (components, directives, pipes, services, etc) should be declared and exported through modules.
+            <a href="https://angular.io/docs/ts/latest/guide/ngmodule.html" target="_blank">Read more about NgModule.</a>
+        </p>
+        <p>
+            You can check out the latest version of Clarity seed to get a sample setup with the new module, routers, and testing setup. You can also check out <a href="https://github.com/juliemr/ng2-test-seed" target="_blank">this
+            excellent seed that covers basic unit tests using TestBed.</a>
+        </p>
+        <p>
+            Please refer to <a href="https://github.com/angular/angular/blob/master/CHANGELOG.md" target="_blank">Angular's CHANGELOG for a complete list of breaking changes</a> that might impact your application.
+        </p>
+    </li>
+</ul>

--- a/src/releases/0.5/0.5.1.html
+++ b/src/releases/0.5/0.5.1.html
@@ -1,0 +1,34 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Stack View Editor: Implement HTML/CSS to indicate that a value has been changed</h6>
+        <p>
+            Stack View now has a new option <code class="clr-code">clrSbNotifyChange</code> which can be added on a stack block. When the option is set to <code class="clr-code">true</code>, an inidicator showing an update is shown on the stack block.
+        </p>
+    </li>
+    <li>
+        <h6>Implement HTML/CSS for an XL Clarity modal</h6>
+        <p>Clarity Modals now supports an additional size - xl using the <code class="clr-code">.modal-xl</code>. The size can also be set on the modal angular component using the <code class="clr-code">clrModalSize</code> option.</p>
+        <pre>
+<code class="language-html">
+    &lt;clr-modal [(clrModalOpen)]=&quot;::boolean::&quot; [clrModalSize]=&quot;'xl'&quot;&gt;
+</code>
+</pre>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>Modal animation backdrop is sliding</li>
+    <li bug-fix>Add font-family declaration to body tag</li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>Implement and document new row selection color</li>
+    <li>Update website to use Angular 2.0.0</li>
+    <li>Documentation - Buttons</li>
+    <li>Export demo components in Clarity</li>
+    <li>Document Vertical Spacing Between Components</li>
+    <li>Add a date to Release Notes on web</li>
+</ul>

--- a/src/releases/0.5/0.5.2.html
+++ b/src/releases/0.5/0.5.2.html
@@ -1,0 +1,15 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Remove WOFF2 and TrueType fonts</h6>
+        <p>
+            Removed WOFF2 and TrueType font types. This change reduces the size of the minified Clarity css from 661KB to 488KB.
+        </p>
+    </li>
+    <li>
+        <h6>Update Sketch Template for Clarity Components</h6>
+        <p>
+            Various updates of the Clarity Sketch template to keep it in sync with Clarity 0.5.0.
+        </p>
+    </li>
+</ul>

--- a/src/releases/0.5/0.5.3.html
+++ b/src/releases/0.5/0.5.3.html
@@ -1,0 +1,37 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li new-component>
+        <h6>Wizard Component</h6>
+        <p>
+            0.5.3 includes a new Angular component - Wizards. A wizard can be created using the following markup:
+        </p>
+        <pre>
+    <code class="language-html">
+    &lt;clr-wizard #wizard [(clrWizardOpen)]=&quot;open&quot; [clrWizardSize]=&quot;'lg'&quot;&gt;
+        &lt;div class=&quot;wizard-title&quot;&gt;Wizard Title&lt;/div&gt;
+
+        &lt;clr-wizard-step&gt;Step 1&lt;/clr-wizard-step&gt;
+        &lt;clr-wizard-step&gt;Step 2&lt;/clr-wizard-step&gt;
+        &lt;clr-wizard-step&gt;Step 3&lt;/clr-wizard-step&gt;
+
+        &lt;clr-wizard-page&gt;Content for step 1&lt;/clr-wizard-page&gt;
+        &lt;clr-wizard-page&gt;Content for step 2&lt;/clr-wizard-page&gt;
+        &lt;clr-wizard-page&gt;Content for step 3&lt;/clr-wizard-page&gt;
+    &lt;/clr-wizard&gt;
+    </code>
+</pre>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>Inverse button: disabled inverse button is too dark</li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>Documentation for Wizard Component</li>
+    <li>Add spinner component size variations</li>
+    <li>Restructure the left side navigation on the components page of the website</li>
+    <li>Improvements to the login page component</li>
+</ul>

--- a/src/releases/0.5/0.5.4.html
+++ b/src/releases/0.5/0.5.4.html
@@ -1,0 +1,68 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li new-component>
+        <h6>Clarity Icons</h6>
+        <p>
+            Clarity presents pixel perfect and scalable SVG-based icons. This new icon system gives you complete control over the color, orientation, and visibility all the way down to individual paths in the icon through standard CSS. Multi-colored icons are as
+            easy as setting fill and stroke colors in your styles! Clarity Icons comes with a set of predefined color treatments as CSS classnames that you can use in your HTML right away with more icons and styles on the way.
+        </p>
+        <pre><code class="language-html">
+        &lt;clr-icon shape=&quot;info&quot; class=&quot;icon-size-[sm/md/lg]&quot;&gt;&lt;/clr-icon&gt;
+        &lt;clr-icon shape=&quot;info&quot; class=&quot;icon-orient-[up/right/down/left]&quot;&gt;&lt;/clr-icon&gt;
+        &lt;clr-icon shape=&quot;info&quot; class=&quot;icon-color&mdash;[highlight/inverse/success/danger/warning/info]&quot;&gt;&lt;/clr-icon&gt;
+    </code></pre>
+    </li>
+    <li new-component>
+        <h6>Responsive Navigation</h6>
+        <p>
+            Clarity Navigation is now responsive! You can make up to two levels of navigation responsive. Add the <code class="clr-code">clr-nav-level</code> input to your navigation level and assign it a value of <code class="clr-code">1</code> for primary
+            navigation and <code class="clr-code">2</code> for secondary navigation.
+        </p>
+        <pre><code class="language-html">
+        &lt;clr-main-container&gt;
+        &lt;clr-header&gt;
+            ...
+            &lt;div class=&quot;header-nav&quot; [clr-nav-level]=&quot;1&quot;&gt;
+                ...
+            &lt;/div&gt;
+            ...
+        &lt;/clr-header&gt;
+        &lt;div class=&quot;content-container&quot;&gt;
+            &lt;main class=&quot;content-area&quot;&gt;
+                ...
+            &lt;/main&gt;
+            &lt;nav class=&quot;sidenav&quot; [clr-nav-level]=&quot;2&quot;&gt;
+                ...
+            &lt;/nav&gt;
+        &lt;/div&gt;
+    &lt;/clr-main-container&gt;
+    </code></pre>
+    </li>
+    <li>
+        <h6>Login Form Updates</h6>
+        <p>
+            Login Form now supports a select box for Authentication Source and a link for Sign Up.
+        </p>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>Clicking on the magnifying glass should focus on the search bar in the header</li>
+    <li bug-fix>Header overflow bug</li>
+    <li bug-fix>Make wizard not depend on container&#39;s css class</li>
+    <li bug-fix>Increase specificity of close class in wizard</li>
+    <li bug-fix>Documentation section change killed responsive sidenav on the website</li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>Document improvements to login screen</li>
+    <li>Add Documentation on Responsive Header</li>
+    <li>Add Copyright, Trademark, etc information to the website</li>
+    <li>Determine naming conventions for Clarity Icon system</li>
+    <li>Implement Clarity Icons</li>
+    <li>Highlight the current step in a wizard better</li>
+    <li>Create Do and Don&#39;t images for Clarity web site</li>
+    <li>Cleanup typings</li>
+</ul>

--- a/src/releases/0.5/0.5.5.html
+++ b/src/releases/0.5/0.5.5.html
@@ -1,0 +1,22 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6><a routerLink="/documentation/iconography">Clarity Icons Documentation</a></h6>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>Fix caching issue on Website</li>
+    <li bug-fix>Override wizard&#39;s style to fix nav style dependency</li>
+    <li bug-fix>Hide Header Nav End Divider</li>
+    <li bug-fix>IE Header Search placeholder issue</li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>Update ReadMe on the github repo</li>
+    <li>Prepare the Clarity code of conduct</li>
+    <li>Upgrade to Angular 2.1.0</li>
+    <li>Seed Responsive Nav Updates</li>
+</ul>

--- a/src/releases/0.5/0.5.6.html
+++ b/src/releases/0.5/0.5.6.html
@@ -1,0 +1,4 @@
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>Fixed issue with Clarity Icon dependencies</li>
+</ul>

--- a/src/releases/0.6/0.6.1.html
+++ b/src/releases/0.6/0.6.1.html
@@ -1,0 +1,103 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Cards Refactor</h6>
+        <p>Cards have been refactored to support a simple semantic layout:</p>
+        <pre>
+        <code clr-code-highlight="language-html">
+        &lt;div class="card"&gt;
+            &lt;div class="card-header"&gt;
+                ...
+            &lt;/div&gt;
+            &lt;div class="card-block"&gt;
+                ...
+            &lt;/div&gt;
+            &lt;div class="card-footer"&gt;
+                ...
+            &lt;/div&gt;
+        &lt;/div&gt;
+        </code></pre>
+
+        <ul class="list">
+            Additional features added are:
+            <li>Cards in CSS Columns</li>
+            <li>Card Media Blocks</li>
+            <li>Images can now be added anywhere inside of the card using the <code class="clr-code">.card-img</code> class</li>
+        </ul>
+
+        <p>We recommend moving all card actions into the card footer.</p>
+
+        <div class="alert alert-warning">
+            <div class="alert-item">
+                <span class="alert-text">
+                    Following classes are being deprecated and will be removed in 0.8.0.
+                </span>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-xs-12 col-sm-12 col-md-6">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th class="left">Deprecated Classes</th>
+                            <th class="left">Replacement</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="left"><code class="clr-code">.card-link</code></td>
+                            <td class="left">Flat/Link Buttons - <code class="clr-code">.btn .btn-sm .btn-link</code></td>
+                        </tr>
+                        <tr>
+                            <td class="left"><code class="clr-code">.group</code></td>
+                            <td class="left"><code class="clr-code">.card-media-block</code></td>
+                        </tr>
+                        <tr>
+                            <td class="left"><code class="clr-code">.card-overflow-menu</code></td>
+                            <td class="left"><code class="clr-code">.dropdown</code></td>
+                        </tr>
+                        <tr>
+                            <td class="left"><code class="clr-code">.card-img-top</code></td>
+                            <td class="left">Use the <code class="clr-code">.card-img</code> class irrespective of where the image is placed in the card.</td>
+                        </tr>
+                        <tr>
+                            <td class="left"><code class="clr-code">.card-divider</code></td>
+                            <td class="left">Card header and blocks now have a bottom border which act as card dividers. Multiple card blocks can be used to divide the content. This helps organizing the content in cards.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </li>
+    <li>
+        <h6>SASS Overrides</h6>
+        <p>
+            To give our users the ability to easily customize the look of the Clarity Design System, we have added over-rideable variables to the Clarity SASS source code.
+        </p>
+        <p>
+            We recommend that users make customizations in the
+            <code>utils/_overwrite.clarity.scss</code>. This file was created so that users of the Clarity Design System could overwrite our default variable assignments in one location.
+        </p>
+        <p>
+            Overriding the default Clarity Design System variables requires you to rebuild Clarity with your own SASS build.
+        </p>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>Fixed alignment of card footer links in MSEdge</li>
+    <li bug-fix>Applied not-allowed cursor to disabled text areas</li>
+    <li bug-fix>Fixed an issue where dropdowns were getting cut off in the headers</li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>Added favicon to website</li>
+    <li>Updated sketch template to version 0.6.0</li>
+    <li>Moved to TravisCI</li>
+    <li>Overhauled website navigation to allow it to run at root level locally and as a project github pages</li>
+    <li>Designed a new logo for the Clarity Design System</li>
+    <li>Moved website to github</li>
+</ul>

--- a/src/releases/0.6/0.6.2.html
+++ b/src/releases/0.6/0.6.2.html
@@ -1,0 +1,46 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Added size attribute to Clarity Icons</h6>
+        <p>
+            You can now set an icon size through <code class="clr-code">size</code> attribute. The sizes set through <code class="clr-code">size</code> attribute overrides the CSS size style. If you don't set either the size attribute or the CSS size
+            style, the size defaults to 16 by 16 pixels.
+        </p>
+        <pre><code class="language-html">
+    &lt;clr-icon shape=&quot;info&quot; size=&quot;12&quot;&gt;&lt;/clr-icon&gt;
+    &lt;clr-icon shape=&quot;info&quot; size=&quot;16&quot;&gt;&lt;/clr-icon&gt;
+    &lt;clr-icon shape=&quot;info&quot; size=&quot;36&quot;&gt;&lt;/clr-icon&gt;
+    &lt;clr-icon shape=&quot;info&quot; size=&quot;48&quot;&gt;&lt;/clr-icon&gt;
+    &lt;clr-icon shape=&quot;info&quot; size=&quot;64&quot;&gt;&lt;/clr-icon&gt;
+    &lt;clr-icon shape=&quot;info&quot; size=&quot;72&quot;&gt;&lt;/clr-icon&gt;
+</code>
+</pre>
+        <div class="alert alert-warning">
+            <div class="alert-item">
+                <span class="alert-text">
+                    Please note that <code class="clr-code">.icon-size-[sm/md/lg]</code> classes
+                    are being deprecated and will be removed in 0.8.0.
+                </span>
+            </div>
+        </div>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>Fixed issue with Clarity Icons throwing an error in IE10 </li>
+    <li bug-fix>Cleaned up checkbox positioning so it is more resilient to positioning and size modifications</li>
+    <li bug-fix>Fixed scrolling issue with website on iOS</li>
+    <li bug-fix>Fixed broken links and image paths from website navigation rearchitecture for github-pages</li>
+    <li bug-fix>Fixed vertical alignment issue with alerts</li>
+    <li bug-fix>Corrected a margin issue with link/flat buttons in forms</li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul class="list">
+    <li>Updated TravisCI and added steps to github workflow</li>
+    <li>Created Angular component for checkboxes — documentation coming soon</li>
+    <li>Implemented website homepage redesign</li>
+    <li>Continued cleanup of website content</li>
+    <li>Improved installation instructions for Clarity Icons, Clarity UI, and Clarity Angular</li>
+</ul>

--- a/src/releases/0.6/0.6.3.html
+++ b/src/releases/0.6/0.6.3.html
@@ -1,0 +1,10 @@
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>Fixed tests that were failing because of replace anchor tags in tabs/nav with buttons</li>
+    <li bug-fix>Fixed an issue with the nav/tab highlight not overlapping the border below the tabs</li>
+    <li bug-fix>Removed extra padding around progress blocks in cards after cards refactor in 0.6.2</li>
+    <li bug-fix>Fixed test in dropdowns that was returning a false positive</li>
+    <li bug-fix>Hid the branding icon on tablet-sized and smaller screens</li>
+    <li bug-fix>Fixed an issue with alignment and cursors on responsive nav triggers</li>
+    <li bug-fix>Fixed a vertical alignment issue in small alerts</li>
+</ul>

--- a/src/releases/0.6/0.6.4.html
+++ b/src/releases/0.6/0.6.4.html
@@ -1,0 +1,5 @@
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>Removed Dropdown Menu close transition to eliminate the delay when the dropdown menu was closed</li>
+    <li bug-fix>Replaced the SVG for the login background to use inline styles instead of the style tag to fix the IE 11 - Windows 10 issue with login backgrounds</li>
+</ul>

--- a/src/releases/0.7/0.7.0.html
+++ b/src/releases/0.7/0.7.0.html
@@ -1,0 +1,155 @@
+<h2>Highlights</h2>
+
+
+<ul class="list-unstyled whats-new-highlights">
+    <li new-component>
+        <h6>New component: Datagrid</h6>
+        <p>
+            Clarity NG now provides a Datagrid Angular component. It comes with a first set of features, including sorting, filtering, pagination and multi-selection. It supports pre-loaded data as well as server-driven data, where only the currently displayed items
+            are loaded in the browser. We have a list of features we plan to add in future versions, but we welcome any feedback or request to add to that list or change its priorities.
+        </p>
+        <p>
+            Clarity's Datagrid uses a declarative interface, so you can use it as you would use an HTML table, directly in your templates. Here is a basic example with simple objects:
+        </p>
+        <pre><code class="language-html">
+    &lt;clr-datagrid&gt;
+        &lt;{{ 'clr-dg-column [clrDgField]' }}=&quot;'id'&quot;&gt;User ID&lt;/clr-dg-column&gt;
+        &lt;{{ 'clr-dg-column [clrDgField]' }}=&quot;'name'&quot;&gt;Name&lt;/clr-dg-column&gt;
+        &lt;{{ 'clr-dg-column [clrDgField]' }}=&quot;'creation'&quot;&gt;Creation date&lt;/clr-dg-column&gt;
+        &lt;{{ 'clr-dg-row *clrDgItems='}}&quot;{{'let user of users'}}&quot;&gt;
+            &lt;{{'clr-dg-cell'}}&gt;{{ '{{ ' }}{{ 'user.id' }}{{ ' }' }}{{ '}' }}&lt;/clr-dg-cell&gt;
+            &lt;{{'clr-dg-cell'}}&gt;{{ '{{ ' }}{{ 'user.name' }}{{ ' }' }}{{ '}' }}&lt;/clr-dg-cell&gt;
+            &lt;{{'clr-dg-cell'}}&gt;{{ '{{ ' }}{{ 'user.creation | date' }}{{ ' }' }}{{ '}' }}&lt;/clr-dg-cell&gt;
+        &lt;/clr-dg-row&gt;
+
+        &lt;{{'clr-dg-footer'}}&gt;
+            {{ '{{ ' }}{{ 'pagination.firstItem + 1' }}{{ ' }' }}{{ '}' }} - {{ '{{ ' }}{{ 'pagination.lastItem + 1' }}{{ ' }' }}{{ '}' }}
+            of {{ '{{ ' }}{{ 'pagination.totalItems' }}{{ ' }' }}{{ '}' }}
+            &lt;{{'clr-dg-pagination #pagination [clrDgPageSize]'}}=&quot;10&quot;&gt;&lt;/clr-dg-pagination&gt;
+        &lt;/clr-dg-footer&gt;
+    &lt;/clr-datagrid&gt;
+</code>
+</pre>
+
+        <p>
+            We will have full documentation coming soon for more advanced examples.
+        </p>
+
+    </li>
+
+
+
+
+
+
+    <li breaking-change>
+        <h6>Replace Font Awesome with Clarity Icons</h6>
+
+        <p>
+            Clarity UI now depends on <a routerLink="/documentation/iconography">Clarity Icons</a> instead of Font Awesome for iconography.
+        </p>
+
+        <p><b>Breaking Change</b></p>
+
+        <p><a routerLink="/documentation/dropdowns">Dropdowns</a> Toggles now have an updated markup:</p>
+
+        <pre><code class="language-html">
+    &lt;button class=&quot;dropdown-toggle btn btn-outline-primary&quot;&gt;
+        Dropdown
+        &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
+    &lt;/button&gt;
+</code>
+</pre>
+
+        <p><b>Note:</b> Clarity recommends that you use a button for the toggle. The button can contain either text or an icon.</p>
+
+        <p><b>Deprecation</b></p>
+
+        <div class="alert alert-info">
+            <div class="alert-item">
+                <span class="alert-text">
+                    Existing support for font icons in Clarity components is now being deprecated and will be removed in 0.8.0.
+                    Clarity recommends using Clarity Icons.
+                </span>
+            </div>
+        </div>
+
+        <p>
+            Use the following markup for using Clarity Icons in Branding, Header Nav and Header Actions:
+        </p>
+
+        <pre><code class="language-html">
+    &lt;header class=&quot;header-6&quot;&gt;
+      &lt;div class=&quot;branding&quot;&gt;
+          &lt;a href=&quot;javascript://&quot; class=&quot;nav-link&quot;&gt;
+              &lt;clr-icon shape=&quot;vm-bug&quot;&gt;&lt;/clr-icon&gt;
+              &lt;span class=&quot;title&quot;&gt;Project Clarity&lt;/span&gt;
+          &lt;/a&gt;
+      &lt;/div&gt;
+      &lt;div class=&quot;header-nav&quot;&gt;
+          &lt;a href=&quot;javascript://&quot; class=&quot;nav-link nav-icon&quot;&gt;
+              &lt;clr-icon shape=&quot;cloud&quot;&gt;&lt;/clr-icon&gt;
+          &lt;/a&gt;
+          &lt;a href=&quot;javascript://&quot; class=&quot;active nav-link nav-icon&quot;&gt;
+              &lt;clr-icon shape=&quot;folder&quot;&gt;&lt;/clr-icon&gt;
+          &lt;/a&gt;
+      &lt;/div&gt;
+      &lt;form class=&quot;search&quot;&gt;
+          &lt;label for=&quot;search_input&quot;&gt;
+              &lt;input id=&quot;search_input&quot; type=&quot;text&quot; placeholder=&quot;Search for keywords...&quot;&gt;
+          &lt;/label&gt;
+      &lt;/form&gt;
+      &lt;div class=&quot;header-actions&quot;&gt;
+          &lt;div class=&quot;dropdown bottom-right&quot;&gt;
+              &lt;button class=&quot;dropdown-toggle nav-icon&quot;&gt;
+                  &lt;clr-icon shape=&quot;user&quot;&gt;&lt;/clr-icon&gt;
+                  &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
+              &lt;/button&gt;
+              &lt;div class=&quot;dropdown-menu&quot;&gt;
+                  &lt;a href=&quot;javascript://&quot; class=&quot;dropdown-item&quot;&gt;About&lt;/a&gt;
+                  &lt;a href=&quot;javascript://&quot; class=&quot;dropdown-item&quot;&gt;Preferences&lt;/a&gt;
+                  &lt;a href=&quot;javascript://&quot; class=&quot;dropdown-item&quot;&gt;Logout&lt;/a&gt;
+              &lt;/div&gt;
+          &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/header&gt;
+</code>
+</pre>
+    </li>
+
+
+
+    <li breaking-change>
+
+        <h6>Refactor Angular Dropdown Component</h6>
+
+        <p>The Angular <a routerLink="/documentation/dropdowns">Dropdowns</a> component now uses attribute directives for dropdown toggles and menu items</p>
+
+        <p><b>Breaking Change</b></p>
+
+        <ol class="list">
+            <li><code class="clr-code">clrDropdownToggle</code> should be used to indicate a dropdown toggle used in the angular dropdown component</li>
+            <li><code class="clr-code">clrDropdownItem</code> should be used to indicate a dropdown item in the angular dropdown component</li>
+        </ol>
+
+        <pre><code class="language-html">
+    &lt;clr-dropdown [clrMenuPosition]=&quot;'bottom-right'&quot;&gt;
+      &lt;button class=&quot;btn btn-outline-primary&quot; clrDropdownToggle&gt;
+          Dropdown
+          &lt;clr-icon shape=&quot;caret&quot; class=&quot;icon-orient-down&quot;&gt;&lt;/clr-icon&gt;
+      &lt;/button&gt;
+      &lt;div class=&quot;dropdown-menu&quot;&gt;
+          &lt;label class=&quot;dropdown-header&quot;&gt;Dropdown header&lt;/label&gt;
+          &lt;a href=&quot;javascript://&quot; clrDropdownItem&gt;Action 1&lt;/a&gt;
+          &lt;a href=&quot;javascript://&quot; clrDropdownItem&gt;Action 2&lt;/a&gt;
+          &lt;a href=&quot;javascript://&quot; class=&quot;disabled&quot; clrDropdownItem&gt;Disabled Action&lt;/a&gt;
+          &lt;div class=&quot;dropdown-divider&quot;&gt;&lt;/div&gt;
+          &lt;a href=&quot;javascript://&quot; clrDropdownItem&gt;Link 1&lt;/a&gt;
+          &lt;a href=&quot;javascript://&quot; clrDropdownItem&gt;Link 2&lt;/a&gt;
+      &lt;/div&gt;
+    &lt;/clr-dropdown&gt;
+</code>
+</pre>
+
+    </li>
+</ul>

--- a/src/releases/0.7/0.7.1.html
+++ b/src/releases/0.7/0.7.1.html
@@ -1,0 +1,37 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Updated to TypeScript 2.0 and Angular 2.2.0</h6>
+        <p>
+            With the 0.7.1 release, Clarity has been updated to the latest versions of Angular and Typescript.
+        </p>
+    </li>
+    <li>
+        <h6>Documentation improvements on website</h6>
+        <p>
+            In response to requests from the community, the Clarity team updated the layout and design of the documentation section of the website. We're hoping these improvements make our research and code examples easier to read and navigate.
+        </p>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>Fixed a font weight issue with text links in Clarity headers</li>
+    <li bug-fix>Fixed an issue with the alignment of arrows in stackview labels that was introduced after the move away from icon fonts</li>
+    <li bug-fix>Fixed tests that were failing because of replace anchor tags in tabs/nav with buttons</li>
+    <li bug-fix>Fixed an issue with the nav/tab highlight not overlapping the border below the tabs</li>
+    <li bug-fix>Removed extra padding around progress blocks in cards after cards refactor in 0.6.2</li>
+    <li bug-fix>Fixed test in dropdowns that was returning a false positive</li>
+    <li bug-fix>Hid the branding icon on tablet-sized and smaller screens</li>
+    <li bug-fix>Fixed an issue with alignment and cursors on responsive nav triggers</li>
+    <li bug-fix>Fixed a vertical alignment issue in small alerts</li>
+    <li bug-fix>Fixed a peer dependency issue in Clarity Icons that was linking directly to Custom Elements' GitHub repo instead of npm</li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul>
+    <li>Added copyright information to all files in the repository</li>
+    <li>Updated the website and README with instructions on using Clarity with angular-cli
+    </li>
+    <li>Various website and documentation updates</li>
+</ul>

--- a/src/releases/0.7/0.7.2.html
+++ b/src/releases/0.7/0.7.2.html
@@ -1,0 +1,30 @@
+<h2>Highlights</h2>
+<ul class="list-unstyled whats-new-highlights">
+    <li>
+        <h6>Core icon set for Clarity Icons</h6>
+        <p>
+            With 0.7.2, Clarity has released <a routerLink="/documentation/iconography">a core
+            set of 50 icons</a>. In addition, the orientation of icons can now be adjusted by using the <code>dir</code> attribute or appending the direction to the existing <code>shape</code> attribute.
+        </p>
+    </li>
+    <li>
+        <h6>Sketch template updated to 0.7</h6>
+        <p>
+            The Clarity Sketch template has been updated to 0.7. With the latest release, Sketch template has been rebuilt from the ground up to improve organization and presentation of the components.
+        </p>
+    </li>
+</ul>
+
+<h2>Bug Fixes</h2>
+<ul class="list">
+    <li bug-fix>Fixed change detection for smart iterators on datagrid</li>
+    <li bug-fix>Unnecessary log messages removed from the datagrid</li>
+</ul>
+
+<h2>Other Changes</h2>
+<ul>
+    <li>Added placeholder for empty state on data grids</li>
+    <li>Sketch template link added to website homepage</li>
+    <li>Coding guidelines added to github repo</li>
+    <li>Various website enhancements and bug fixes</li>
+</ul>

--- a/src/releases/release-list.json
+++ b/src/releases/release-list.json
@@ -1,20 +1,201 @@
 {
-  "current": "0.7.4",
-  "all": {
-    "0.7.4": {
-      "date": "Dec 8, 2016",
-      "sketch": "0.7.3",
-      "commit": "a136aba0b3ddab135743c7d74a5289bf7e007199"
-    },
-    "0.7.3": {
-      "date": "Dec 1, 2016",
-      "sketch": "0.7.3",
-      "commit": "7792acd165674b970cdaa33e89eb8371d8b487a6"
-    },
-    "0.6.0": {
-      "date": "Oct 28, 2016",
-      "sketch": "0.6.0",
-      "commit": "d332f6a632fd3570f6924324089466f555baf853"
+    "current": "0.7.4",
+    "all": {
+        "0.7.4": {
+            "date": "Dec 8, 2016",
+            "sketch": "0.7.3",
+            "commit": "a136aba0b3ddab135743c7d74a5289bf7e007199"
+        },
+        "0.7.3": {
+            "date": "Dec 1, 2016",
+            "sketch": "0.7.3",
+            "commit": "7792acd165674b970cdaa33e89eb8371d8b487a6"
+        },
+        "0.7.2": {
+            "date": "Nov 23, 2016",
+            "sketch": "0.7.0",
+            "commit": "5172211a6e126b2213f95a6ee90611c497ec908a"
+        },
+        "0.7.1": {
+            "date": "Nov 18, 2016",
+            "sketch": "0.7.0",
+            "commit": "475a6c1cf5fdab4043e03261e671dcec51a512b2"
+        },
+        "0.7.0": {
+            "date": "Nov 11, 2016",
+            "sketch": "0.7.0",
+            "commit": "29c547cde08e6c3add9fa5b40b34c516ae90574f"
+        },
+
+
+
+        "0.6.4": {
+            "date": "Dec 8, 2016",
+            "sketch": "0.6.0",
+            "commit": "6b14e3abfcf49a2c3d857e0ffd79dbaaa9f3a695"
+        },
+        "0.6.3": {
+            "date": "Nov 18, 2016",
+            "sketch": "0.6.0",
+            "commit": "f2d82388e7b6a9d40e3e82442755ee32ee7b89c1"
+        },
+        "0.6.2": {
+            "date": "Nov 11, 2016",
+            "sketch": "0.6.0",
+            "commit": "d44dfc753e8ffce2d845aff7892e718704601e8e"
+        },
+        "0.6.1": {
+            "date": "Nov 4, 2016",
+            "sketch": "0.6.0",
+            "commit": "ce43e65ab3dd9706e24ca0697df84043a163f83e"
+        },
+        "0.6.0": {
+            "date": "Oct 28, 2016",
+            "sketch": "0.6.0",
+            "commit": "d332f6a632fd3570f6924324089466f555baf853"
+        },
+
+
+
+        "0.5.6": {
+            "date": "Oct 27, 2016",
+            "sketch": "0.5.0",
+            "commit": null
+        },
+        "0.5.5": {
+            "date": "Oct 21, 2016",
+            "sketch": "0.5.0",
+            "commit": null
+        },
+        "0.5.4": {
+            "date": "Oct 14, 2016",
+            "sketch": "0.5.0",
+            "commit": null
+        },
+        "0.5.3": {
+            "date": "Oct 6, 2016",
+            "sketch": "0.5.0",
+            "commit": null
+        },
+        "0.5.2": {
+            "date": "Sep 30, 2016",
+            "sketch": "0.5.0",
+            "commit": null
+        },
+        "0.5.1": {
+            "date": "Sep 22, 2016",
+            "sketch": "0.5.0",
+            "commit": null
+        },
+        "0.5.0": {
+            "date": "Sep 15, 2016",
+            "sketch": "0.5.0",
+            "commit": null
+        },
+
+
+
+        "0.4.3": {
+            "date": "Sep 22, 2016",
+            "sketch": "0.3.0",
+            "commit": null
+        },
+        "0.4.2": {
+            "date": "Sep 15, 2016",
+            "sketch": "0.3.0",
+            "commit": null
+        },
+        "0.4.1": {
+            "date": "Sep 7, 2016",
+            "sketch": "0.3.0",
+            "commit": null
+        },
+        "0.4.0": {
+            "date": "Aug 30, 2016",
+            "sketch": "0.3.0",
+            "commit": null
+        },
+
+
+
+        "0.3.6": {
+            "date": "Aug 26, 2016",
+            "sketch": "0.3.0",
+            "commit": null
+        },
+        "0.3.5": {
+            "date": "Aug 26, 2016",
+            "sketch": "0.3.0",
+            "commit": null
+        },
+        "0.3.4": {
+            "date": "Aug 18, 2016",
+            "sketch": "0.3.0",
+            "commit": null
+        },
+        "0.3.3": {
+            "date": "Aug 10, 2016",
+            "sketch": "0.3.0",
+            "commit": null
+        },
+        "0.3.2": {
+            "date": "Aug 4, 2016",
+            "sketch": "0.3.0",
+            "commit": null
+        },
+        "0.3.1": {
+            "date": "Jul 27, 2016",
+            "sketch": "0.3.0",
+            "commit": null
+        },
+        "0.3.0": {
+            "date": "Jul 20, 2016",
+            "sketch": "0.3.0",
+            "commit": null
+        },
+
+
+
+
+        "0.2.10": {
+            "date": "Jul 21, 2016",
+            "sketch": "0.2.5",
+            "commit": null
+        },
+        "0.2.9": {
+            "date": "Jul 17, 2016",
+            "sketch": "0.2.5",
+            "commit": null
+        },
+        "0.2.8": {
+            "date": "Jul 7, 2016",
+            "sketch": "0.2.5",
+            "commit": null
+        },
+        "0.2.7": {
+            "date": "Jun 30, 2016",
+            "sketch": "0.2.5",
+            "commit": null
+        },
+        "0.2.6": {
+            "date": "Jun 23, 2016",
+            "sketch": "0.2.5",
+            "commit": null
+        },
+        "0.2.5": {
+            "date": "Jun 16, 2016",
+            "sketch": "0.2.5",
+            "commit": null
+        },
+        "0.2.4": {
+            "date": "Jun 9, 2016",
+            "sketch": "0.2.5",
+            "commit": null
+        },
+        "0.2.3": {
+            "date": "Jun 2, 2016",
+            "sketch": "0.2.5",
+            "commit": null
+        }
     }
-  }
 }

--- a/src/releases/release-templates-stub.ts
+++ b/src/releases/release-templates-stub.ts
@@ -5,5 +5,43 @@
 export const TEMPLATES = {
   "0.7.4": require("./0.7/0.7.4.html"),
   "0.7.3": require("./0.7/0.7.3.html"),
+  "0.7.2": require("./0.7/0.7.2.html"),
+  "0.7.1": require("./0.7/0.7.1.html"),
+  "0.7.0": require("./0.7/0.7.0.html"),
+
+  "0.6.4": require("./0.6/0.6.4.html"),
+  "0.6.3": require("./0.6/0.6.3.html"),
+  "0.6.2": require("./0.6/0.6.2.html"),
+  "0.6.1": require("./0.6/0.6.1.html"),
   "0.6.0": require("./0.6/0.6.0.html"),
+
+  "0.5.6": require("./0.5/0.5.6.html"),
+  "0.5.5": require("./0.5/0.5.5.html"),
+  "0.5.4": require("./0.5/0.5.4.html"),
+  "0.5.3": require("./0.5/0.5.3.html"),
+  "0.5.2": require("./0.5/0.5.2.html"),
+  "0.5.1": require("./0.5/0.5.1.html"),
+  "0.5.0": require("./0.5/0.5.0.html"),
+
+  "0.4.3": require("./0.4/0.4.3.html"),
+  "0.4.2": require("./0.4/0.4.2.html"),
+  "0.4.1": require("./0.4/0.4.1.html"),
+  "0.4.0": require("./0.4/0.4.0.html"),
+
+  "0.3.6": require("./0.3/0.3.6.html"),
+  "0.3.5": require("./0.3/0.3.5.html"),
+  "0.3.4": require("./0.3/0.3.4.html"),
+  "0.3.3": require("./0.3/0.3.3.html"),
+  "0.3.2": require("./0.3/0.3.2.html"),
+  "0.3.1": require("./0.3/0.3.1.html"),
+  "0.3.0": require("./0.3/0.3.0.html"),
+
+  "0.2.10": require("./0.2/0.2.10.html"),
+  "0.2.9": require("./0.2/0.2.9.html"),
+  "0.2.8": require("./0.2/0.2.8.html"),
+  "0.2.7": require("./0.2/0.2.7.html"),
+  "0.2.6": require("./0.2/0.2.6.html"),
+  "0.2.5": require("./0.2/0.2.5.html"),
+  "0.2.4": require("./0.2/0.2.4.html"),
+  "0.2.3": require("./0.2/0.2.3.html")
 };


### PR DESCRIPTION
• converted release notes up to and including 0.7.4 into components
• verified release notes contain the expected content
• had to do some major escaping on the data grid code sample on 0.7.0

Tested in:
✔︎ Chrome

Closes: #10

Signed-off-by: Scott Mathis <smathis@vmware.com>

[web] converting release notes to components part two

Signed-off-by: Scott Mathis <smathis@vmware.com>