### PR TITLE
correct typo in documentation

### DIFF
--- a/src/pages/documentation/input-fields.html
+++ b/src/pages/documentation/input-fields.html
@@ -12,10 +12,12 @@
     <p>You can set the direction of the tooltip using these classes:</p>
 
     <ul>
-        <li>.top-right (default)</li>
-        <li>.top-left</li>
-        <li>.bottom-right</li>
-        <li>.bottom-left</li>
+        <li>.tooltip-top-right (default)</li>
+        <li>.tooltip-top-left</li>
+        <li>.tooltip-right</li>
+        <li>.tooltip-left</li>  
+        <li>.tooltip-bottom-right</li>
+        <li>.tooltip-bottom-left</li>
     </ul>
 
     <p>You can set the size of the tooltips using these classes:</p>


### PR DESCRIPTION
corrected typo in documentation and added missing css selectors 

see: https://github.com/vmware/clarity/blob/master/src/clarity-angular/tooltips/_tooltips.clarity.scss#L131